### PR TITLE
virtualization: unguarded-availability-new to error

### DIFF
--- a/virtualization.go
+++ b/virtualization.go
@@ -1,7 +1,7 @@
 package vz
 
 /*
-#cgo darwin CFLAGS: -x objective-c -fno-objc-arc
+#cgo darwin CFLAGS: -x objective-c -fno-objc-arc -Werror=unguarded-availability-new
 #cgo darwin LDFLAGS: -lobjc -framework Foundation -framework Virtualization
 # include "virtualization.h"
 */


### PR DESCRIPTION
The `unguarded-availability-new` warning to the error.

Currently, can compile even if the host OS is Canalina. define `-Werror=unguarded-availability-new` will warning to error.

```
virtualization.m:45:5: warning: 'VZLinuxBootLoader' is only available on macOS 11.0 or newer [-Wunguarded-availability-new]
```