### PR TITLE
Add github actions support

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -1,0 +1,34 @@
+name: Test compilation on latest macOS
+on:
+  push:
+    branches:
+    - "master"
+  pull_request: {}
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+        - macOS-11
+        go:
+        - 1.16
+        - 1.17
+    steps:
+      - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
+      - run: echo "🐧 This job is now running on a ${{ runner.os }} server hosted by GitHub!"
+      - run: echo "🔎 The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go }}
+      - run: echo "💡 The ${{ github.repository }} repository has been cloned to the runner."
+      - run: echo "🖥️ The workflow is now ready to test your code on the runner."
+      - name: Build
+        run: cd example && make
+      - name: vet
+        run: go vet ./...
+      - run: echo "🍏 This job's status is ${{ job.status }}."


### PR DESCRIPTION
This builds example/ and runs go vet with go 1.16 and 1.17 on macOS 11