### PR TITLE
Fix shouldAcceptNewConnectionHandler compilation error

### DIFF
--- a/socket.go
+++ b/socket.go
@@ -180,7 +180,11 @@ func shouldAcceptNewConnectionHandler(listenerPtr, connPtr, devicePtr unsafe.Poi
 
 	// see: startHandler
 	conn := newVirtioSocketConnection(connPtr)
-	return (C.BOOL)(shouldAcceptNewConnectionHandlers[listenerPtr](conn))
+	if shouldAcceptNewConnectionHandlers[listenerPtr](conn) {
+		return 1
+	}
+
+	return 0
 }
 
 // VirtioSocketConnection is a port-based connection between the guest operating system and the host computer.


### PR DESCRIPTION
'bool' cannot be converted to 'BOOL' on my macOS/golang 1.16 and 1.17.3:

./socket.go:222:17: cannot convert
shouldAcceptNewConnectionHandlers[listenerPtr](conn) (type bool) to type
_Ctype_schar

Before this commit:
https://github.com/cfergeau/vz/actions/runs/1573537306
After this commit:
https://github.com/cfergeau/vz/actions/runs/1573558835