### PR TITLE
network: Fix SetMacAddress capitalization

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -84,7 +84,7 @@ func main() {
 	config.SetNetworkDevicesVirtualMachineConfiguration([]*vz.VirtioNetworkDeviceConfiguration{
 		networkConfig,
 	})
-	networkConfig.SetMacAddress(vz.NewRandomLocallyAdministeredMACAddress())
+	networkConfig.SetMACAddress(vz.NewRandomLocallyAdministeredMACAddress())
 
 	// entropy
 	entropyConfig := vz.NewVirtioEntropyDeviceConfiguration()

--- a/network.go
+++ b/network.go
@@ -162,7 +162,7 @@ func NewVirtioNetworkDeviceConfiguration(attachment NetworkDeviceAttachment) *Vi
 	return config
 }
 
-func (v *VirtioNetworkDeviceConfiguration) SetMacAddress(macAddress *MACAddress) {
+func (v *VirtioNetworkDeviceConfiguration) SetMACAddress(macAddress *MACAddress) {
 	C.setNetworkDevicesVZMACAddress(v.Ptr(), macAddress.Ptr())
 }
 


### PR DESCRIPTION
This changes it to SetMACAddress to make it consistent with the
MACAddress type, with NewRandomLocallyAdministeredMACAddress, ...