### PR TITLE
add support for passing kernel as byte slice

### DIFF
--- a/virtualization.h
+++ b/virtualization.h
@@ -29,6 +29,7 @@ bool shouldAcceptNewConnectionHandler(void *listener, void *connection, void *so
 
 /* BootLoader */
 void *newVZLinuxBootLoader(const char *kernelPath);
+void *newVZLinuxBootLoaderMemory(const char *kernel);
 void setCommandLineVZLinuxBootLoader(void *bootLoaderPtr, const char *commandLine);
 void setInitialRamdiskURLVZLinuxBootLoader(void *bootLoaderPtr, const char *ramdiskPath);
 

--- a/virtualization.m
+++ b/virtualization.m
@@ -59,6 +59,21 @@ void *newVZLinuxBootLoader(const char *kernelPath)
 }
 
 /*!
+ @abstract Create a VZLinuxBootLoader with the Linux kernel passed as base64-encoded dataURL string.
+ @param kernel  kernel contents as base64-encoded string.
+*/
+void *newVZLinuxBootLoaderMemory(const char *kernel)
+{
+    VZLinuxBootLoader *ret;
+    @autoreleasepool {
+        NSString *kernelDataString = [NSString stringWithUTF8String:kernel];
+        NSURL *kernelURL = [NSURL URLWithString:kernelDataString];
+        ret = [[VZLinuxBootLoader alloc] initWithKernelURL:kernelURL];
+    }
+    return ret;
+}
+
+/*!
  @abstract Set the command-line parameters.
  @param bootLoader VZLinuxBootLoader
  @param commandLine The command-line parameters passed to the kernel on boot.


### PR DESCRIPTION
The interface may not be perfect, but it does work and is backwards-compatible. I tested it, was able to pass in a compressed kernel by decompressing it in memory and passing the `[]byte` slice.