### PR TITLE
Fix typos in API doc

### DIFF
--- a/virtualization.go
+++ b/virtualization.go
@@ -238,7 +238,7 @@ func (v *VirtualMachine) Start(fn func(error)) {
 // Pause a virtual machine that is in Running state.
 //
 // - fn parameter called after the virtual machine has been successfully paused or on error.
-// The error parameter passed to the block is null if the start was successful.
+// The error parameter passed to the block is null if the pause was successful.
 func (v *VirtualMachine) Pause(fn func(error)) {
 	h, done := makeHandler(fn)
 	handler := cgo.NewHandle(h)
@@ -262,7 +262,7 @@ func (v *VirtualMachine) Resume(fn func(error)) {
 // RequestStop requests that the guest turns itself off.
 //
 // If returned error is not nil, assigned with the error if the request failed.
-// Returens true if the request was made successfully.
+// Returns true if the request was made successfully.
 func (v *VirtualMachine) RequestStop() (bool, error) {
 	nserr := newNSErrorAsNil()
 	nserrPtr := nserr.Ptr()

--- a/virtualization.m
+++ b/virtualization.m
@@ -371,7 +371,7 @@ void *newVZFileHandleSerialPortAttachment(int readFileDescriptor, int writeFileD
  @param filePath The path of the file for the attachment on the local file system.
  @param shouldAppend True if the file should be opened in append mode, false otherwise.
         When a file is opened in append mode, writing to that file will append to the end of it.
- @param error If not nil, used to report errors if intialization fails.
+ @param error If not nil, used to report errors if initialization fails.
  @return A VZFileSerialPortAttachment on success. Nil otherwise and the error parameter is populated if set.
  */
 void *newVZFileSerialPortAttachment(const char *filePath, bool shouldAppend, void **error)


### PR DESCRIPTION
This fixes a few typos I noticed in the API documentation.