### PR TITLE
Handle better x86_64/aarch64 builds

### DIFF
--- a/example/linux/Makefile
+++ b/example/linux/Makefile
@@ -8,3 +8,9 @@ codesign:
 .PHONY: build
 build:
 	go build -o virtualization .
+
+.PHONY: cross-build virtualization-amd64 virtualization-arm64
+cross-build: virtualization-amd64 virtualization-arm64
+
+virtualization-amd64 virtualization-arm64: virtualization-%:
+	CGO_ENABLED=1 GOOS=darwin GOARCH=$* go build -o $@ .

--- a/example/macOS/Makefile
+++ b/example/macOS/Makefile
@@ -7,4 +7,4 @@ codesign:
 
 .PHONY: build
 build:
-	go build -o virtualization .
+	CGO_ENABLED=1 GOOS=darwin GOARCH=arm64 go build -o virtualization .


### PR DESCRIPTION
This PR adds a `make cross-build` target to example/linux to build
both x86_64 and aarch64 binaries, which can be useful for testing on multiple
macbooks with different CPUs.
This also always builds an aarch64 binaries for example/macOS as the API it
uses are not available on x86_64 machines.