### PR TITLE
Allow to use github.com/Code-Hex/vz/v2 from macOS 11/macOS 10

### DIFF
--- a/audio.go
+++ b/audio.go
@@ -36,7 +36,13 @@ type VirtioSoundDeviceConfiguration struct {
 var _ AudioDeviceConfiguration = (*VirtioSoundDeviceConfiguration)(nil)
 
 // NewVirtioSoundDeviceConfiguration creates a new sound device configuration.
-func NewVirtioSoundDeviceConfiguration() *VirtioSoundDeviceConfiguration {
+//
+// This is only supported on macOS 12 and newer, ErrUnsupportedOSVersion will
+// be returned on older versions.
+func NewVirtioSoundDeviceConfiguration() (*VirtioSoundDeviceConfiguration, error) {
+	if macosMajorVersionLessThan(12) {
+		return nil, ErrUnsupportedOSVersion
+	}
 	config := &VirtioSoundDeviceConfiguration{
 		pointer: pointer{
 			ptr: C.newVZVirtioSoundDeviceConfiguration(),
@@ -45,7 +51,7 @@ func NewVirtioSoundDeviceConfiguration() *VirtioSoundDeviceConfiguration {
 	runtime.SetFinalizer(config, func(self *VirtioSoundDeviceConfiguration) {
 		self.Release()
 	})
-	return config
+	return config, nil
 }
 
 // SetStreams sets the list of audio streams exposed by this device.
@@ -80,7 +86,13 @@ type VirtioSoundDeviceHostInputStreamConfiguration struct {
 var _ VirtioSoundDeviceStreamConfiguration = (*VirtioSoundDeviceHostInputStreamConfiguration)(nil)
 
 // NewVirtioSoundDeviceHostInputStreamConfiguration creates a new PCM stream configuration of input audio data from host.
-func NewVirtioSoundDeviceHostInputStreamConfiguration() *VirtioSoundDeviceHostInputStreamConfiguration {
+//
+// This is only supported on macOS 12 and newer, ErrUnsupportedOSVersion will
+// be returned on older versions.
+func NewVirtioSoundDeviceHostInputStreamConfiguration() (*VirtioSoundDeviceHostInputStreamConfiguration, error) {
+	if macosMajorVersionLessThan(12) {
+		return nil, ErrUnsupportedOSVersion
+	}
 	config := &VirtioSoundDeviceHostInputStreamConfiguration{
 		pointer: pointer{
 			ptr: C.newVZVirtioSoundDeviceHostInputStreamConfiguration(),
@@ -89,7 +101,7 @@ func NewVirtioSoundDeviceHostInputStreamConfiguration() *VirtioSoundDeviceHostIn
 	runtime.SetFinalizer(config, func(self *VirtioSoundDeviceHostInputStreamConfiguration) {
 		self.Release()
 	})
-	return config
+	return config, nil
 }
 
 // VirtioSoundDeviceHostOutputStreamConfiguration is a struct that
@@ -105,7 +117,13 @@ type VirtioSoundDeviceHostOutputStreamConfiguration struct {
 var _ VirtioSoundDeviceStreamConfiguration = (*VirtioSoundDeviceHostOutputStreamConfiguration)(nil)
 
 // NewVirtioSoundDeviceHostOutputStreamConfiguration creates a new sounds device output stream configuration.
-func NewVirtioSoundDeviceHostOutputStreamConfiguration() *VirtioSoundDeviceHostOutputStreamConfiguration {
+//
+// This is only supported on macOS 12 and newer, ErrUnsupportedOSVersion will
+// be returned on older versions.
+func NewVirtioSoundDeviceHostOutputStreamConfiguration() (*VirtioSoundDeviceHostOutputStreamConfiguration, error) {
+	if macosMajorVersionLessThan(12) {
+		return nil, ErrUnsupportedOSVersion
+	}
 	config := &VirtioSoundDeviceHostOutputStreamConfiguration{
 		pointer: pointer{
 			ptr: C.newVZVirtioSoundDeviceHostOutputStreamConfiguration(),
@@ -114,5 +132,5 @@ func NewVirtioSoundDeviceHostOutputStreamConfiguration() *VirtioSoundDeviceHostO
 	runtime.SetFinalizer(config, func(self *VirtioSoundDeviceHostOutputStreamConfiguration) {
 		self.Release()
 	})
-	return config
+	return config, nil
 }

--- a/bootloader.go
+++ b/bootloader.go
@@ -68,7 +68,14 @@ func WithInitrd(initrdPath string) LinuxBootLoaderOption {
 }
 
 // NewLinuxBootLoader creates a LinuxBootLoader with the Linux kernel passed as Path.
-func NewLinuxBootLoader(vmlinuz string, opts ...LinuxBootLoaderOption) *LinuxBootLoader {
+//
+// This is only supported on macOS 11 and newer, ErrUnsupportedOSVersion will
+// be returned on older versions.
+func NewLinuxBootLoader(vmlinuz string, opts ...LinuxBootLoaderOption) (*LinuxBootLoader, error) {
+	if macosMajorVersionLessThan(11) {
+		return nil, ErrUnsupportedOSVersion
+	}
+
 	vmlinuzPath := charWithGoString(vmlinuz)
 	defer vmlinuzPath.Free()
 	bootLoader := &LinuxBootLoader{
@@ -85,5 +92,5 @@ func NewLinuxBootLoader(vmlinuz string, opts ...LinuxBootLoaderOption) *LinuxBoo
 	for _, opt := range opts {
 		opt(bootLoader)
 	}
-	return bootLoader
+	return bootLoader, nil
 }

--- a/bootloader_arm64.go
+++ b/bootloader_arm64.go
@@ -21,7 +21,14 @@ type MacOSBootLoader struct {
 var _ BootLoader = (*MacOSBootLoader)(nil)
 
 // NewMacOSBootLoader creates a new MacOSBootLoader struct.
-func NewMacOSBootLoader() *MacOSBootLoader {
+//
+// This is only supported on macOS 12 and newer, ErrUnsupportedOSVersion will
+// be returned on older versions.
+func NewMacOSBootLoader() (*MacOSBootLoader, error) {
+	if macosMajorVersionLessThan(12) {
+		return nil, ErrUnsupportedOSVersion
+	}
+
 	bootLoader := &MacOSBootLoader{
 		pointer: pointer{
 			ptr: C.newVZMacOSBootLoader(),
@@ -30,5 +37,5 @@ func NewMacOSBootLoader() *MacOSBootLoader {
 	runtime.SetFinalizer(bootLoader, func(self *MacOSBootLoader) {
 		self.Release()
 	})
-	return bootLoader
+	return bootLoader, nil
 }

--- a/console.go
+++ b/console.go
@@ -40,7 +40,14 @@ type FileHandleSerialPortAttachment struct {
 //
 // read parameter is an *os.File for reading from the file.
 // write parameter is an *os.File for writing to the file.
-func NewFileHandleSerialPortAttachment(read, write *os.File) *FileHandleSerialPortAttachment {
+//
+// This is only supported on macOS 11 and newer, ErrUnsupportedOSVersion will
+// be returned on older versions.
+func NewFileHandleSerialPortAttachment(read, write *os.File) (*FileHandleSerialPortAttachment, error) {
+	if macosMajorVersionLessThan(11) {
+		return nil, ErrUnsupportedOSVersion
+	}
+
 	attachment := &FileHandleSerialPortAttachment{
 		pointer: pointer{
 			ptr: C.newVZFileHandleSerialPortAttachment(
@@ -52,7 +59,7 @@ func NewFileHandleSerialPortAttachment(read, write *os.File) *FileHandleSerialPo
 	runtime.SetFinalizer(attachment, func(self *FileHandleSerialPortAttachment) {
 		self.Release()
 	})
-	return attachment
+	return attachment, nil
 }
 
 var _ SerialPortAttachment = (*FileSerialPortAttachment)(nil)
@@ -74,7 +81,14 @@ type FileSerialPortAttachment struct {
 // - path of the file for the attachment on the local file system.
 // - shouldAppend True if the file should be opened in append mode, false otherwise.
 //    When a file is opened in append mode, writing to that file will append to the end of it.
+//
+// This is only supported on macOS 11 and newer, ErrUnsupportedOSVersion will
+// be returned on older versions.
 func NewFileSerialPortAttachment(path string, shouldAppend bool) (*FileSerialPortAttachment, error) {
+	if macosMajorVersionLessThan(11) {
+		return nil, ErrUnsupportedOSVersion
+	}
+
 	cpath := charWithGoString(path)
 	defer cpath.Free()
 
@@ -108,7 +122,14 @@ type VirtioConsoleDeviceSerialPortConfiguration struct {
 }
 
 // NewVirtioConsoleDeviceSerialPortConfiguration creates a new NewVirtioConsoleDeviceSerialPortConfiguration.
-func NewVirtioConsoleDeviceSerialPortConfiguration(attachment SerialPortAttachment) *VirtioConsoleDeviceSerialPortConfiguration {
+//
+// This is only supported on macOS 11 and newer, ErrUnsupportedOSVersion will
+// be returned on older versions.
+func NewVirtioConsoleDeviceSerialPortConfiguration(attachment SerialPortAttachment) (*VirtioConsoleDeviceSerialPortConfiguration, error) {
+	if macosMajorVersionLessThan(11) {
+		return nil, ErrUnsupportedOSVersion
+	}
+
 	config := &VirtioConsoleDeviceSerialPortConfiguration{
 		pointer: pointer{
 			ptr: C.newVZVirtioConsoleDeviceSerialPortConfiguration(
@@ -119,5 +140,5 @@ func NewVirtioConsoleDeviceSerialPortConfiguration(attachment SerialPortAttachme
 	runtime.SetFinalizer(config, func(self *VirtioConsoleDeviceSerialPortConfiguration) {
 		self.Release()
 	})
-	return config
+	return config, nil
 }

--- a/entropy.go
+++ b/entropy.go
@@ -18,7 +18,14 @@ type VirtioEntropyDeviceConfiguration struct {
 }
 
 // NewVirtioEntropyDeviceConfiguration creates a new Virtio Entropy Device confiuration.
-func NewVirtioEntropyDeviceConfiguration() *VirtioEntropyDeviceConfiguration {
+//
+// This is only supported on macOS 11 and newer, ErrUnsupportedOSVersion will
+// be returned on older versions.
+func NewVirtioEntropyDeviceConfiguration() (*VirtioEntropyDeviceConfiguration, error) {
+	if macosMajorVersionLessThan(11) {
+		return nil, ErrUnsupportedOSVersion
+	}
+
 	config := &VirtioEntropyDeviceConfiguration{
 		pointer: pointer{
 			ptr: C.newVZVirtioEntropyDeviceConfiguration(),
@@ -27,5 +34,5 @@ func NewVirtioEntropyDeviceConfiguration() *VirtioEntropyDeviceConfiguration {
 	runtime.SetFinalizer(config, func(self *VirtioEntropyDeviceConfiguration) {
 		self.Release()
 	})
-	return config
+	return config, nil
 }

--- a/example/linux/main.go
+++ b/example/linux/main.go
@@ -85,12 +85,22 @@ func main() {
 	})
 
 	// network
-	natAttachment := vz.NewNATNetworkDeviceAttachment()
-	networkConfig := vz.NewVirtioNetworkDeviceConfiguration(natAttachment)
+	natAttachment, err := vz.NewNATNetworkDeviceAttachment()
+	if err != nil {
+		panic(err)
+	}
+	networkConfig, err := vz.NewVirtioNetworkDeviceConfiguration(natAttachment)
+	if err != nil {
+		panic(err)
+	}
 	config.SetNetworkDevicesVirtualMachineConfiguration([]*vz.VirtioNetworkDeviceConfiguration{
 		networkConfig,
 	})
-	networkConfig.SetMACAddress(vz.NewRandomLocallyAdministeredMACAddress())
+	mac, err := vz.NewRandomLocallyAdministeredMACAddress()
+	if err != nil {
+		panic(err)
+	}
+	networkConfig.SetMACAddress(mac)
 
 	// entropy
 	entropyConfig, err := vz.NewVirtioEntropyDeviceConfiguration()

--- a/example/linux/main.go
+++ b/example/linux/main.go
@@ -56,11 +56,14 @@ func main() {
 	initrd := os.Getenv("INITRD_PATH")
 	diskPath := os.Getenv("DISKIMG_PATH")
 
-	bootLoader := vz.NewLinuxBootLoader(
+	bootLoader, err := vz.NewLinuxBootLoader(
 		vmlinuz,
 		vz.WithCommandLine(strings.Join(kernelCommandLineArguments, " ")),
 		vz.WithInitrd(initrd),
 	)
+	if err != nil {
+		panic(err)
+	}
 	log.Println("bootLoader:", bootLoader)
 
 	config := vz.NewVirtualMachineConfiguration(

--- a/example/linux/main.go
+++ b/example/linux/main.go
@@ -93,7 +93,10 @@ func main() {
 	networkConfig.SetMACAddress(vz.NewRandomLocallyAdministeredMACAddress())
 
 	// entropy
-	entropyConfig := vz.NewVirtioEntropyDeviceConfiguration()
+	entropyConfig, err := vz.NewVirtioEntropyDeviceConfiguration()
+	if err != nil {
+		panic(err)
+	}
 	config.SetEntropyDevicesVirtualMachineConfiguration([]*vz.VirtioEntropyDeviceConfiguration{
 		entropyConfig,
 	})

--- a/example/linux/main.go
+++ b/example/linux/main.go
@@ -78,8 +78,14 @@ func main() {
 	setRawMode(os.Stdin)
 
 	// console
-	serialPortAttachment := vz.NewFileHandleSerialPortAttachment(os.Stdin, os.Stdout)
-	consoleConfig := vz.NewVirtioConsoleDeviceSerialPortConfiguration(serialPortAttachment)
+	serialPortAttachment, err := vz.NewFileHandleSerialPortAttachment(os.Stdin, os.Stdout)
+	if err != nil {
+		panic(err)
+	}
+	consoleConfig, err := vz.NewVirtioConsoleDeviceSerialPortConfiguration(serialPortAttachment)
+	if err != nil {
+		panic(err)
+	}
 	config.SetSerialPortsVirtualMachineConfiguration([]*vz.VirtioConsoleDeviceSerialPortConfiguration{
 		consoleConfig,
 	})

--- a/example/linux/main.go
+++ b/example/linux/main.go
@@ -66,11 +66,14 @@ func main() {
 	}
 	log.Println("bootLoader:", bootLoader)
 
-	config := vz.NewVirtualMachineConfiguration(
+	config, err := vz.NewVirtualMachineConfiguration(
 		bootLoader,
 		1,
 		2*1024*1024*1024,
 	)
+	if err != nil {
+		panic(err)
+	}
 
 	setRawMode(os.Stdin)
 

--- a/example/linux/main.go
+++ b/example/linux/main.go
@@ -124,7 +124,10 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	storageDeviceConfig := vz.NewVirtioBlockDeviceConfiguration(diskImageAttachment)
+	storageDeviceConfig, err := vz.NewVirtioBlockDeviceConfiguration(diskImageAttachment)
+	if err != nil {
+		panic(err)
+	}
 	config.SetStorageDevicesVirtualMachineConfiguration([]vz.StorageDeviceConfiguration{
 		storageDeviceConfig,
 	})

--- a/example/linux/main.go
+++ b/example/linux/main.go
@@ -150,7 +150,10 @@ func main() {
 		log.Fatal("validation failed", err)
 	}
 
-	vm := vz.NewVirtualMachine(config)
+	vm, err := vz.NewVirtualMachine(config)
+	if err != nil {
+		panic(err)
+	}
 
 	signalCh := make(chan os.Signal, 1)
 	signal.Notify(signalCh, syscall.SIGTERM)

--- a/example/linux/main.go
+++ b/example/linux/main.go
@@ -114,8 +114,12 @@ func main() {
 	})
 
 	// traditional memory balloon device which allows for managing guest memory. (optional)
+	memoryBalloonDevice, err := vz.NewVirtioTraditionalMemoryBalloonDeviceConfiguration()
+	if err != nil {
+		panic(err)
+	}
 	config.SetMemoryBalloonDevicesVirtualMachineConfiguration([]vz.MemoryBalloonDeviceConfiguration{
-		vz.NewVirtioTraditionalMemoryBalloonDeviceConfiguration(),
+		memoryBalloonDevice,
 	})
 
 	// socket device (optional)

--- a/example/linux/main.go
+++ b/example/linux/main.go
@@ -142,8 +142,12 @@ func main() {
 	})
 
 	// socket device (optional)
+	vsockDevice, err := vz.NewVirtioSocketDeviceConfiguration()
+	if err != nil {
+		panic(err)
+	}
 	config.SetSocketDevicesVirtualMachineConfiguration([]vz.SocketDeviceConfiguration{
-		vz.NewVirtioSocketDeviceConfiguration(),
+		vsockDevice,
 	})
 	validated, err := config.Validate()
 	if !validated || err != nil {

--- a/example/linux/main.go
+++ b/example/linux/main.go
@@ -62,7 +62,7 @@ func main() {
 		vz.WithInitrd(initrd),
 	)
 	if err != nil {
-		panic(err)
+		log.Fatalf("bootloader creation failed: %s", err)
 	}
 	log.Println("bootLoader:", bootLoader)
 

--- a/example/linux/main.go
+++ b/example/linux/main.go
@@ -72,7 +72,7 @@ func main() {
 		2*1024*1024*1024,
 	)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to create virtual machine configuration: %s", err)
 	}
 
 	setRawMode(os.Stdin)

--- a/example/linux/main.go
+++ b/example/linux/main.go
@@ -156,7 +156,7 @@ func main() {
 
 	vm, err := vz.NewVirtualMachine(config)
 	if err != nil {
-		panic(err)
+		log.Fatalf("Virtual machine creation failed: %s", err)
 	}
 
 	signalCh := make(chan os.Signal, 1)

--- a/example/linux/main.go
+++ b/example/linux/main.go
@@ -144,7 +144,7 @@ func main() {
 	// socket device (optional)
 	vsockDevice, err := vz.NewVirtioSocketDeviceConfiguration()
 	if err != nil {
-		panic(err)
+		log.Fatalf("virtio-vsock device creation failed: %s", err)
 	}
 	config.SetSocketDevicesVirtualMachineConfiguration([]vz.SocketDeviceConfiguration{
 		vsockDevice,

--- a/example/linux/main.go
+++ b/example/linux/main.go
@@ -135,7 +135,7 @@ func main() {
 	// traditional memory balloon device which allows for managing guest memory. (optional)
 	memoryBalloonDevice, err := vz.NewVirtioTraditionalMemoryBalloonDeviceConfiguration()
 	if err != nil {
-		panic(err)
+		log.Fatalf("Balloon device creation failed: %s", err)
 	}
 	config.SetMemoryBalloonDevicesVirtualMachineConfiguration([]vz.MemoryBalloonDeviceConfiguration{
 		memoryBalloonDevice,

--- a/example/linux/main.go
+++ b/example/linux/main.go
@@ -93,18 +93,18 @@ func main() {
 	// network
 	natAttachment, err := vz.NewNATNetworkDeviceAttachment()
 	if err != nil {
-		panic(err)
+		log.Fatalf("NAT network device creation failed: %s", err)
 	}
 	networkConfig, err := vz.NewVirtioNetworkDeviceConfiguration(natAttachment)
 	if err != nil {
-		panic(err)
+		log.Fatalf("Creation of the networking configuration failed: %s", err)
 	}
 	config.SetNetworkDevicesVirtualMachineConfiguration([]*vz.VirtioNetworkDeviceConfiguration{
 		networkConfig,
 	})
 	mac, err := vz.NewRandomLocallyAdministeredMACAddress()
 	if err != nil {
-		panic(err)
+		log.Fatalf("Random MAC address creation failed: %s", err)
 	}
 	networkConfig.SetMACAddress(mac)
 

--- a/example/linux/main.go
+++ b/example/linux/main.go
@@ -126,7 +126,7 @@ func main() {
 	}
 	storageDeviceConfig, err := vz.NewVirtioBlockDeviceConfiguration(diskImageAttachment)
 	if err != nil {
-		panic(err)
+		log.Fatalf("Block device creation failed: %s", err)
 	}
 	config.SetStorageDevicesVirtualMachineConfiguration([]vz.StorageDeviceConfiguration{
 		storageDeviceConfig,

--- a/example/linux/main.go
+++ b/example/linux/main.go
@@ -111,7 +111,7 @@ func main() {
 	// entropy
 	entropyConfig, err := vz.NewVirtioEntropyDeviceConfiguration()
 	if err != nil {
-		panic(err)
+		log.Fatalf("Entropy device creation failed: %s", err)
 	}
 	config.SetEntropyDevicesVirtualMachineConfiguration([]*vz.VirtioEntropyDeviceConfiguration{
 		entropyConfig,

--- a/example/linux/main.go
+++ b/example/linux/main.go
@@ -80,11 +80,11 @@ func main() {
 	// console
 	serialPortAttachment, err := vz.NewFileHandleSerialPortAttachment(os.Stdin, os.Stdout)
 	if err != nil {
-		panic(err)
+		log.Fatalf("Serial port attachment creation failed: %s", err)
 	}
 	consoleConfig, err := vz.NewVirtioConsoleDeviceSerialPortConfiguration(serialPortAttachment)
 	if err != nil {
-		panic(err)
+		log.Fatalf("Failed to create serial configuration: %s", err)
 	}
 	config.SetSerialPortsVirtualMachineConfiguration([]*vz.VirtioConsoleDeviceSerialPortConfiguration{
 		consoleConfig,

--- a/example/macOS/installer.go
+++ b/example/macOS/installer.go
@@ -23,7 +23,10 @@ func installMacOS(ctx context.Context) error {
 	}
 	vm := vz.NewVirtualMachine(config)
 
-	installer := vz.NewMacOSInstaller(vm, restoreImagePath)
+	installer, err := vz.NewMacOSInstaller(vm, restoreImagePath)
+	if err != nil {
+		return err
+	}
 
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -65,7 +68,10 @@ func createMacInstallerPlatformConfiguration(macOSConfiguration *vz.MacOSConfigu
 		return nil, fmt.Errorf("failed to write hardware model data: %w", err)
 	}
 
-	machineIdentifier := vz.NewMacMachineIdentifier()
+	machineIdentifier, err := vz.NewMacMachineIdentifier()
+	if err != nil {
+		return nil, err
+	}
 	if err := CreateFileAndWriteTo(
 		machineIdentifier.DataRepresentation(),
 		GetMachineIdentifierPath(),
@@ -84,5 +90,5 @@ func createMacInstallerPlatformConfiguration(macOSConfiguration *vz.MacOSConfigu
 		vz.WithAuxiliaryStorage(auxiliaryStorage),
 		vz.WithHardwareModel(hardwareModel),
 		vz.WithMachineIdentifier(machineIdentifier),
-	), nil
+	)
 }

--- a/example/macOS/installer.go
+++ b/example/macOS/installer.go
@@ -21,7 +21,10 @@ func installMacOS(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to setup config: %w", err)
 	}
-	vm := vz.NewVirtualMachine(config)
+	vm, err := vz.NewVirtualMachine(config)
+	if err != nil {
+		return err
+	}
 
 	installer, err := vz.NewMacOSInstaller(vm, restoreImagePath)
 	if err != nil {

--- a/example/macOS/main.go
+++ b/example/macOS/main.go
@@ -167,10 +167,12 @@ func createGraphicsDeviceConfiguration() (*vz.MacGraphicsDeviceConfiguration, er
 	return graphicDeviceConfig, nil
 }
 
-func createNetworkDeviceConfiguration() *vz.VirtioNetworkDeviceConfiguration {
-	natAttachment := vz.NewNATNetworkDeviceAttachment()
-	networkConfig := vz.NewVirtioNetworkDeviceConfiguration(natAttachment)
-	return networkConfig
+func createNetworkDeviceConfiguration() (*vz.VirtioNetworkDeviceConfiguration, error) {
+	natAttachment, err := vz.NewNATNetworkDeviceAttachment()
+	if err != nil {
+		return nil, err
+	}
+	return vz.NewVirtioNetworkDeviceConfiguration(natAttachment)
 }
 
 func createPointingDeviceConfiguration() (*vz.USBScreenCoordinatePointingDeviceConfiguration, error) {
@@ -254,8 +256,12 @@ func setupVMConfiguration(platformConfig vz.PlatformConfiguration) (*vz.VirtualM
 	}
 	config.SetStorageDevicesVirtualMachineConfiguration([]vz.StorageDeviceConfiguration{blockDeviceConfig})
 
+	networkDeviceConfig, err := createNetworkDeviceConfiguration()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create network device configuration: %w", err)
+	}
 	config.SetNetworkDevicesVirtualMachineConfiguration([]*vz.VirtioNetworkDeviceConfiguration{
-		createNetworkDeviceConfiguration(),
+		networkDeviceConfig,
 	})
 
 	pointingDeviceConfig, err := createPointingDeviceConfiguration()

--- a/example/macOS/main.go
+++ b/example/macOS/main.go
@@ -148,8 +148,7 @@ func createBlockDeviceConfiguration(diskPath string) (*vz.VirtioBlockDeviceConfi
 	if err != nil {
 		return nil, err
 	}
-	storageDeviceConfig := vz.NewVirtioBlockDeviceConfiguration(diskImageAttachment)
-	return storageDeviceConfig, nil
+	return vz.NewVirtioBlockDeviceConfiguration(diskImageAttachment)
 }
 
 func createGraphicsDeviceConfiguration() (*vz.MacGraphicsDeviceConfiguration, error) {

--- a/example/macOS/main.go
+++ b/example/macOS/main.go
@@ -181,15 +181,25 @@ func createKeyboardConfiguration() (*vz.USBKeyboardConfiguration, error) {
 	return vz.NewUSBKeyboardConfiguration()
 }
 
-func createAudioDeviceConfiguration() *vz.VirtioSoundDeviceConfiguration {
-	audioConfig := vz.NewVirtioSoundDeviceConfiguration()
-	inputStream := vz.NewVirtioSoundDeviceHostInputStreamConfiguration()
-	outputStream := vz.NewVirtioSoundDeviceHostOutputStreamConfiguration()
+func createAudioDeviceConfiguration() (*vz.VirtioSoundDeviceConfiguration, error) {
+	audioConfig, err := vz.NewVirtioSoundDeviceConfiguration()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create sound device configuration: %w", err)
+	}
+	inputStream, err := vz.NewVirtioSoundDeviceHostInputStreamConfiguration()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create input stream configuration: %w", err)
+	}
+
+	outputStream, err := vz.NewVirtioSoundDeviceHostOutputStreamConfiguration()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create output stream configuration: %w", err)
+	}
 	audioConfig.SetStreams(
 		inputStream,
 		outputStream,
 	)
-	return audioConfig
+	return audioConfig, nil
 }
 
 func createMacPlatformConfiguration() (*vz.MacPlatformConfiguration, error) {
@@ -261,8 +271,12 @@ func setupVMConfiguration(platformConfig vz.PlatformConfiguration) (*vz.VirtualM
 		keyboardDeviceConfig,
 	})
 
+	audioDeviceConfig, err := createAudioDeviceConfiguration()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create audio device configuration: %w", err)
+	}
 	config.SetAudioDevicesVirtualMachineConfiguration([]vz.AudioDeviceConfiguration{
-		createAudioDeviceConfiguration(),
+		audioDeviceConfig,
 	})
 
 	validated, err := config.Validate()

--- a/example/macOS/main.go
+++ b/example/macOS/main.go
@@ -45,7 +45,10 @@ func runVM(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	vm := vz.NewVirtualMachine(config)
+	vm, err := vz.NewVirtualMachine(config)
+	if err != nil {
+		return err
+	}
 
 	errCh := make(chan error, 1)
 

--- a/example/macOS/main.go
+++ b/example/macOS/main.go
@@ -232,11 +232,14 @@ func setupVMConfiguration(platformConfig vz.PlatformConfiguration) (*vz.VirtualM
 		return nil, err
 	}
 
-	config := vz.NewVirtualMachineConfiguration(
+	config, err := vz.NewVirtualMachineConfiguration(
 		bootloader,
 		computeCPUCount(),
 		computeMemorySize(),
 	)
+	if err != nil {
+		return nil, err
+	}
 	config.SetPlatformVirtualMachineConfiguration(platformConfig)
 	graphicsDeviceConfig, err := createGraphicsDeviceConfiguration()
 	if err != nil {

--- a/example/macOS/main.go
+++ b/example/macOS/main.go
@@ -173,11 +173,11 @@ func createNetworkDeviceConfiguration() *vz.VirtioNetworkDeviceConfiguration {
 	return networkConfig
 }
 
-func createPointingDeviceConfiguration() *vz.USBScreenCoordinatePointingDeviceConfiguration {
+func createPointingDeviceConfiguration() (*vz.USBScreenCoordinatePointingDeviceConfiguration, error) {
 	return vz.NewUSBScreenCoordinatePointingDeviceConfiguration()
 }
 
-func createKeyboardConfiguration() *vz.USBKeyboardConfiguration {
+func createKeyboardConfiguration() (*vz.USBKeyboardConfiguration, error) {
 	return vz.NewUSBKeyboardConfiguration()
 }
 
@@ -245,12 +245,20 @@ func setupVMConfiguration(platformConfig vz.PlatformConfiguration) (*vz.VirtualM
 		createNetworkDeviceConfiguration(),
 	})
 
+	pointingDeviceConfig, err := createPointingDeviceConfiguration()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create pointing device configuration: %w", err)
+	}
 	config.SetPointingDevicesVirtualMachineConfiguration([]vz.PointingDeviceConfiguration{
-		createPointingDeviceConfiguration(),
+		pointingDeviceConfig,
 	})
 
+	keyboardDeviceConfig, err := createKeyboardConfiguration()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create keyboard device configuration: %w", err)
+	}
 	config.SetKeyboardsVirtualMachineConfiguration([]vz.KeyboardConfiguration{
-		createKeyboardConfiguration(),
+		keyboardDeviceConfig,
 	})
 
 	config.SetAudioDevicesVirtualMachineConfiguration([]vz.AudioDeviceConfiguration{

--- a/example_test.go
+++ b/example_test.go
@@ -1,0 +1,18 @@
+package vz_test
+
+import (
+	"errors"
+
+	"github.com/Code-Hex/vz/v2"
+)
+
+func ExampleErrUnsupportedOSVersion() {
+	// The vz.NewSharedDirectory API is only available on macOS 11 or newer
+	_, err := vz.NewSharedDirectory("/example/path", false)
+	if errors.Is(err, vz.ErrUnsupportedOSVersion) {
+		// When running on macOS 10, an error will be returned when
+		// trying to use NewSharedDirectory().
+	}
+	// When running on macOS 11 or newer, vz.NewSharedDirectory() can be
+	// called without getting an ErrUnsupportedOSVersion error.
+}

--- a/graphics_arm64.go
+++ b/graphics_arm64.go
@@ -21,7 +21,14 @@ type MacGraphicsDeviceConfiguration struct {
 var _ GraphicsDeviceConfiguration = (*MacGraphicsDeviceConfiguration)(nil)
 
 // NewMacGraphicsDeviceConfiguration creates a new MacGraphicsDeviceConfiguration.
-func NewMacGraphicsDeviceConfiguration() *MacGraphicsDeviceConfiguration {
+//
+// This is only supported on macOS 12 and newer, ErrUnsupportedOSVersion will
+// be returned on older versions.
+func NewMacGraphicsDeviceConfiguration() (*MacGraphicsDeviceConfiguration, error) {
+	if macosMajorVersionLessThan(12) {
+		return nil, ErrUnsupportedOSVersion
+	}
+
 	graphicsConfiguration := &MacGraphicsDeviceConfiguration{
 		pointer: pointer{
 			ptr: C.newVZMacGraphicsDeviceConfiguration(),
@@ -30,7 +37,7 @@ func NewMacGraphicsDeviceConfiguration() *MacGraphicsDeviceConfiguration {
 	runtime.SetFinalizer(graphicsConfiguration, func(self *MacGraphicsDeviceConfiguration) {
 		self.Release()
 	})
-	return graphicsConfiguration
+	return graphicsConfiguration, nil
 }
 
 // SetDisplays sets the displays associated with this graphics device.
@@ -51,7 +58,14 @@ type MacGraphicsDisplayConfiguration struct {
 // NewMacGraphicsDisplayConfiguration creates a new MacGraphicsDisplayConfiguration.
 //
 // Creates a display configuration with the specified pixel dimensions and pixel density.
-func NewMacGraphicsDisplayConfiguration(widthInPixels int64, heightInPixels int64, pixelsPerInch int64) *MacGraphicsDisplayConfiguration {
+//
+// This is only supported on macOS 12 and newer, ErrUnsupportedOSVersion will
+// be returned on older versions.
+func NewMacGraphicsDisplayConfiguration(widthInPixels int64, heightInPixels int64, pixelsPerInch int64) (*MacGraphicsDisplayConfiguration, error) {
+	if macosMajorVersionLessThan(12) {
+		return nil, ErrUnsupportedOSVersion
+	}
+
 	graphicsDisplayConfiguration := &MacGraphicsDisplayConfiguration{
 		pointer: pointer{
 			ptr: C.newVZMacGraphicsDisplayConfiguration(
@@ -64,5 +78,5 @@ func NewMacGraphicsDisplayConfiguration(widthInPixels int64, heightInPixels int6
 	runtime.SetFinalizer(graphicsDisplayConfiguration, func(self *MacGraphicsDisplayConfiguration) {
 		self.Release()
 	})
-	return graphicsDisplayConfiguration
+	return graphicsDisplayConfiguration, nil
 }

--- a/keyboard.go
+++ b/keyboard.go
@@ -29,7 +29,13 @@ type USBKeyboardConfiguration struct {
 var _ KeyboardConfiguration = (*USBKeyboardConfiguration)(nil)
 
 // NewUSBKeyboardConfiguration creates a new USB keyboard configuration.
-func NewUSBKeyboardConfiguration() *USBKeyboardConfiguration {
+//
+// This is only supported on macOS 12 and newer, ErrUnsupportedOSVersion will
+// be returned on older versions.
+func NewUSBKeyboardConfiguration() (*USBKeyboardConfiguration, error) {
+	if macosMajorVersionLessThan(12) {
+		return nil, ErrUnsupportedOSVersion
+	}
 	config := &USBKeyboardConfiguration{
 		pointer: pointer{
 			ptr: C.newVZUSBKeyboardConfiguration(),
@@ -38,5 +44,5 @@ func NewUSBKeyboardConfiguration() *USBKeyboardConfiguration {
 	runtime.SetFinalizer(config, func(self *USBKeyboardConfiguration) {
 		self.Release()
 	})
-	return config
+	return config, nil
 }

--- a/memory_balloon.go
+++ b/memory_balloon.go
@@ -31,7 +31,14 @@ type VirtioTraditionalMemoryBalloonDeviceConfiguration struct {
 }
 
 // NewVirtioTraditionalMemoryBalloonDeviceConfiguration creates a new VirtioTraditionalMemoryBalloonDeviceConfiguration.
-func NewVirtioTraditionalMemoryBalloonDeviceConfiguration() *VirtioTraditionalMemoryBalloonDeviceConfiguration {
+//
+// This is only supported on macOS 11 and newer, ErrUnsupportedOSVersion will
+// be returned on older versions.
+func NewVirtioTraditionalMemoryBalloonDeviceConfiguration() (*VirtioTraditionalMemoryBalloonDeviceConfiguration, error) {
+	if macosMajorVersionLessThan(11) {
+		return nil, ErrUnsupportedOSVersion
+	}
+
 	config := &VirtioTraditionalMemoryBalloonDeviceConfiguration{
 		pointer: pointer{
 			ptr: C.newVZVirtioTraditionalMemoryBalloonDeviceConfiguration(),
@@ -40,5 +47,5 @@ func NewVirtioTraditionalMemoryBalloonDeviceConfiguration() *VirtioTraditionalMe
 	runtime.SetFinalizer(config, func(self *VirtioTraditionalMemoryBalloonDeviceConfiguration) {
 		self.Release()
 	})
-	return config
+	return config, nil
 }

--- a/network.go
+++ b/network.go
@@ -48,7 +48,14 @@ type NATNetworkDeviceAttachment struct {
 var _ NetworkDeviceAttachment = (*NATNetworkDeviceAttachment)(nil)
 
 // NewNATNetworkDeviceAttachment creates a new NATNetworkDeviceAttachment.
-func NewNATNetworkDeviceAttachment() *NATNetworkDeviceAttachment {
+//
+// This is only supported on macOS 11 and newer, ErrUnsupportedOSVersion will
+// be returned on older versions.
+func NewNATNetworkDeviceAttachment() (*NATNetworkDeviceAttachment, error) {
+	if macosMajorVersionLessThan(11) {
+		return nil, ErrUnsupportedOSVersion
+	}
+
 	attachment := &NATNetworkDeviceAttachment{
 		pointer: pointer{
 			ptr: C.newVZNATNetworkDeviceAttachment(),
@@ -57,7 +64,7 @@ func NewNATNetworkDeviceAttachment() *NATNetworkDeviceAttachment {
 	runtime.SetFinalizer(attachment, func(self *NATNetworkDeviceAttachment) {
 		self.Release()
 	})
-	return attachment
+	return attachment, nil
 }
 
 // BridgedNetworkDeviceAttachment represents a physical interface on the host computer.
@@ -79,7 +86,14 @@ type BridgedNetworkDeviceAttachment struct {
 var _ NetworkDeviceAttachment = (*BridgedNetworkDeviceAttachment)(nil)
 
 // NewBridgedNetworkDeviceAttachment creates a new BridgedNetworkDeviceAttachment with networkInterface.
-func NewBridgedNetworkDeviceAttachment(networkInterface BridgedNetwork) *BridgedNetworkDeviceAttachment {
+//
+// This is only supported on macOS 11 and newer, ErrUnsupportedOSVersion will
+// be returned on older versions.
+func NewBridgedNetworkDeviceAttachment(networkInterface BridgedNetwork) (*BridgedNetworkDeviceAttachment, error) {
+	if macosMajorVersionLessThan(11) {
+		return nil, ErrUnsupportedOSVersion
+	}
+
 	attachment := &BridgedNetworkDeviceAttachment{
 		pointer: pointer{
 			ptr: C.newVZBridgedNetworkDeviceAttachment(
@@ -90,7 +104,7 @@ func NewBridgedNetworkDeviceAttachment(networkInterface BridgedNetwork) *Bridged
 	runtime.SetFinalizer(attachment, func(self *BridgedNetworkDeviceAttachment) {
 		self.Release()
 	})
-	return attachment
+	return attachment, nil
 }
 
 // FileHandleNetworkDeviceAttachment sending raw network packets over a file handle.
@@ -109,7 +123,14 @@ var _ NetworkDeviceAttachment = (*FileHandleNetworkDeviceAttachment)(nil)
 // NewFileHandleNetworkDeviceAttachment initialize the attachment with a file handle.
 //
 // file parameter is holding a connected datagram socket.
-func NewFileHandleNetworkDeviceAttachment(file *os.File) *FileHandleNetworkDeviceAttachment {
+//
+// This is only supported on macOS 11 and newer, ErrUnsupportedOSVersion will
+// be returned on older versions.
+func NewFileHandleNetworkDeviceAttachment(file *os.File) (*FileHandleNetworkDeviceAttachment, error) {
+	if macosMajorVersionLessThan(11) {
+		return nil, ErrUnsupportedOSVersion
+	}
+
 	attachment := &FileHandleNetworkDeviceAttachment{
 		pointer: pointer{
 			ptr: C.newVZFileHandleNetworkDeviceAttachment(
@@ -120,7 +141,7 @@ func NewFileHandleNetworkDeviceAttachment(file *os.File) *FileHandleNetworkDevic
 	runtime.SetFinalizer(attachment, func(self *FileHandleNetworkDeviceAttachment) {
 		self.Release()
 	})
-	return attachment
+	return attachment, nil
 }
 
 // NetworkDeviceAttachment for a network device attachment.
@@ -148,7 +169,14 @@ type VirtioNetworkDeviceConfiguration struct {
 }
 
 // NewVirtioNetworkDeviceConfiguration creates a new VirtioNetworkDeviceConfiguration with NetworkDeviceAttachment.
-func NewVirtioNetworkDeviceConfiguration(attachment NetworkDeviceAttachment) *VirtioNetworkDeviceConfiguration {
+//
+// This is only supported on macOS 11 and newer, ErrUnsupportedOSVersion will
+// be returned on older versions.
+func NewVirtioNetworkDeviceConfiguration(attachment NetworkDeviceAttachment) (*VirtioNetworkDeviceConfiguration, error) {
+	if macosMajorVersionLessThan(11) {
+		return nil, ErrUnsupportedOSVersion
+	}
+
 	config := &VirtioNetworkDeviceConfiguration{
 		pointer: pointer{
 			ptr: C.newVZVirtioNetworkDeviceConfiguration(
@@ -159,7 +187,7 @@ func NewVirtioNetworkDeviceConfiguration(attachment NetworkDeviceAttachment) *Vi
 	runtime.SetFinalizer(config, func(self *VirtioNetworkDeviceConfiguration) {
 		self.Release()
 	})
-	return config
+	return config, nil
 }
 
 func (v *VirtioNetworkDeviceConfiguration) SetMACAddress(macAddress *MACAddress) {
@@ -173,7 +201,14 @@ type MACAddress struct {
 }
 
 // NewMACAddress creates a new MACAddress with net.HardwareAddr (MAC address).
-func NewMACAddress(macAddr net.HardwareAddr) *MACAddress {
+//
+// This is only supported on macOS 11 and newer, ErrUnsupportedOSVersion will
+// be returned on older versions.
+func NewMACAddress(macAddr net.HardwareAddr) (*MACAddress, error) {
+	if macosMajorVersionLessThan(11) {
+		return nil, ErrUnsupportedOSVersion
+	}
+
 	macAddrChar := charWithGoString(macAddr.String())
 	defer macAddrChar.Free()
 	ma := &MACAddress{
@@ -184,11 +219,18 @@ func NewMACAddress(macAddr net.HardwareAddr) *MACAddress {
 	runtime.SetFinalizer(ma, func(self *MACAddress) {
 		self.Release()
 	})
-	return ma
+	return ma, nil
 }
 
 // NewRandomLocallyAdministeredMACAddress creates a valid, random, unicast, locally administered address.
-func NewRandomLocallyAdministeredMACAddress() *MACAddress {
+//
+// This is only supported on macOS 11 and newer, ErrUnsupportedOSVersion will
+// be returned on older versions.
+func NewRandomLocallyAdministeredMACAddress() (*MACAddress, error) {
+	if macosMajorVersionLessThan(11) {
+		return nil, ErrUnsupportedOSVersion
+	}
+
 	ma := &MACAddress{
 		pointer: pointer{
 			ptr: C.newRandomLocallyAdministeredVZMACAddress(),
@@ -197,7 +239,7 @@ func NewRandomLocallyAdministeredMACAddress() *MACAddress {
 	runtime.SetFinalizer(ma, func(self *MACAddress) {
 		self.Release()
 	})
-	return ma
+	return ma, nil
 }
 
 func (m *MACAddress) String() string {

--- a/platform.go
+++ b/platform.go
@@ -29,7 +29,14 @@ type GenericPlatformConfiguration struct {
 var _ PlatformConfiguration = (*GenericPlatformConfiguration)(nil)
 
 // NewGenericPlatformConfiguration creates a new generic platform configuration.
-func NewGenericPlatformConfiguration() *GenericPlatformConfiguration {
+//
+// This is only supported on macOS 12 and newer, ErrUnsupportedOSVersion will
+// be returned on older versions.
+func NewGenericPlatformConfiguration() (*GenericPlatformConfiguration, error) {
+	if macosMajorVersionLessThan(12) {
+		return nil, ErrUnsupportedOSVersion
+	}
+
 	platformConfig := &GenericPlatformConfiguration{
 		pointer: pointer{
 			ptr: C.newVZGenericPlatformConfiguration(),
@@ -38,5 +45,5 @@ func NewGenericPlatformConfiguration() *GenericPlatformConfiguration {
 	runtime.SetFinalizer(platformConfig, func(self *GenericPlatformConfiguration) {
 		self.Release()
 	})
-	return platformConfig
+	return platformConfig, nil
 }

--- a/platform_arm64.go
+++ b/platform_arm64.go
@@ -67,7 +67,14 @@ func WithAuxiliaryStorage(m *MacAuxiliaryStorage) MacPlatformConfigurationOption
 }
 
 // NewMacPlatformConfiguration creates a new MacPlatformConfiguration. see also it's document.
-func NewMacPlatformConfiguration(opts ...MacPlatformConfigurationOption) *MacPlatformConfiguration {
+//
+// This is only supported on macOS 12 and newer, ErrUnsupportedOSVersion will
+// be returned on older versions.
+func NewMacPlatformConfiguration(opts ...MacPlatformConfigurationOption) (*MacPlatformConfiguration, error) {
+	if macosMajorVersionLessThan(12) {
+		return nil, ErrUnsupportedOSVersion
+	}
+
 	platformConfig := &MacPlatformConfiguration{
 		pointer: pointer{
 			ptr: C.newVZMacPlatformConfiguration(),
@@ -79,7 +86,7 @@ func NewMacPlatformConfiguration(opts ...MacPlatformConfigurationOption) *MacPla
 	runtime.SetFinalizer(platformConfig, func(self *MacPlatformConfiguration) {
 		self.Release()
 	})
-	return platformConfig
+	return platformConfig, nil
 }
 
 // HardwareModel returns the Mac hardware model.

--- a/pointing_device.go
+++ b/pointing_device.go
@@ -30,7 +30,13 @@ type USBScreenCoordinatePointingDeviceConfiguration struct {
 var _ PointingDeviceConfiguration = (*USBScreenCoordinatePointingDeviceConfiguration)(nil)
 
 // NewUSBScreenCoordinatePointingDeviceConfiguration creates a new USBScreenCoordinatePointingDeviceConfiguration.
-func NewUSBScreenCoordinatePointingDeviceConfiguration() *USBScreenCoordinatePointingDeviceConfiguration {
+//
+// This is only supported on macOS 12 and newer, ErrUnsupportedOSVersion will
+// be returned on older versions.
+func NewUSBScreenCoordinatePointingDeviceConfiguration() (*USBScreenCoordinatePointingDeviceConfiguration, error) {
+	if macosMajorVersionLessThan(12) {
+		return nil, ErrUnsupportedOSVersion
+	}
 	config := &USBScreenCoordinatePointingDeviceConfiguration{
 		pointer: pointer{
 			ptr: C.newVZUSBScreenCoordinatePointingDeviceConfiguration(),
@@ -39,5 +45,5 @@ func NewUSBScreenCoordinatePointingDeviceConfiguration() *USBScreenCoordinatePoi
 	runtime.SetFinalizer(config, func(self *USBScreenCoordinatePointingDeviceConfiguration) {
 		self.Release()
 	})
-	return config
+	return config, nil
 }

--- a/shared_folder.go
+++ b/shared_folder.go
@@ -31,7 +31,13 @@ type VirtioFileSystemDeviceConfiguration struct {
 }
 
 // NewVirtioFileSystemDeviceConfiguration create a new VirtioFileSystemDeviceConfiguration.
-func NewVirtioFileSystemDeviceConfiguration(tag string) *VirtioFileSystemDeviceConfiguration {
+//
+// This is only supported on macOS 12 and newer, ErrUnsupportedOSVersion will
+// be returned on older versions.
+func NewVirtioFileSystemDeviceConfiguration(tag string) (*VirtioFileSystemDeviceConfiguration, error) {
+	if macosMajorVersionLessThan(12) {
+		return nil, ErrUnsupportedOSVersion
+	}
 	tagChar := charWithGoString(tag)
 	defer tagChar.Free()
 	fsdConfig := &VirtioFileSystemDeviceConfiguration{
@@ -42,7 +48,7 @@ func NewVirtioFileSystemDeviceConfiguration(tag string) *VirtioFileSystemDeviceC
 	runtime.SetFinalizer(fsdConfig, func(self *VirtioFileSystemDeviceConfiguration) {
 		self.Release()
 	})
-	return fsdConfig
+	return fsdConfig, nil
 }
 
 // SetDirectoryShare sets the directory share associated with this configuration.
@@ -56,7 +62,13 @@ type SharedDirectory struct {
 }
 
 // NewSharedDirectory creates a new shared directory.
-func NewSharedDirectory(dirPath string, readOnly bool) *SharedDirectory {
+//
+// This is only supported on macOS 12 and newer, ErrUnsupportedOSVersion will
+// be returned on older versions.
+func NewSharedDirectory(dirPath string, readOnly bool) (*SharedDirectory, error) {
+	if macosMajorVersionLessThan(12) {
+		return nil, ErrUnsupportedOSVersion
+	}
 	dirPathChar := charWithGoString(dirPath)
 	defer dirPathChar.Free()
 	sd := &SharedDirectory{
@@ -67,7 +79,7 @@ func NewSharedDirectory(dirPath string, readOnly bool) *SharedDirectory {
 	runtime.SetFinalizer(sd, func(self *SharedDirectory) {
 		self.Release()
 	})
-	return sd
+	return sd, nil
 }
 
 // DirectoryShare is the base interface for a directory share.

--- a/socket.go
+++ b/socket.go
@@ -44,7 +44,14 @@ type VirtioSocketDeviceConfiguration struct {
 }
 
 // NewVirtioSocketDeviceConfiguration creates a new VirtioSocketDeviceConfiguration.
-func NewVirtioSocketDeviceConfiguration() *VirtioSocketDeviceConfiguration {
+//
+// This is only supported on macOS 11 and newer, ErrUnsupportedOSVersion will
+// be returned on older versions.
+func NewVirtioSocketDeviceConfiguration() (*VirtioSocketDeviceConfiguration, error) {
+	if macosMajorVersionLessThan(11) {
+		return nil, ErrUnsupportedOSVersion
+	}
+
 	config := &VirtioSocketDeviceConfiguration{
 		pointer: pointer{
 			ptr: C.newVZVirtioSocketDeviceConfiguration(),
@@ -53,7 +60,7 @@ func NewVirtioSocketDeviceConfiguration() *VirtioSocketDeviceConfiguration {
 	runtime.SetFinalizer(config, func(self *VirtioSocketDeviceConfiguration) {
 		self.Release()
 	})
-	return config
+	return config, nil
 }
 
 // VirtioSocketDevice a device that manages port-based connections between the guest system and the host computer.
@@ -137,7 +144,14 @@ var shouldAcceptNewConnectionHandlers = map[unsafe.Pointer]func(conn *VirtioSock
 //
 // The handler is executed asynchronously. Be sure to close the connection used in the handler by calling `conn.Close`.
 // This is to prevent connection leaks.
-func NewVirtioSocketListener(handler func(conn *VirtioSocketConnection, err error)) *VirtioSocketListener {
+//
+// This is only supported on macOS 11 and newer, ErrUnsupportedOSVersion will
+// be returned on older versions.
+func NewVirtioSocketListener(handler func(conn *VirtioSocketConnection, err error)) (*VirtioSocketListener, error) {
+	if macosMajorVersionLessThan(11) {
+		return nil, ErrUnsupportedOSVersion
+	}
+
 	ptr := C.newVZVirtioSocketListener()
 	listener := &VirtioSocketListener{
 		pointer: pointer{
@@ -163,7 +177,7 @@ func NewVirtioSocketListener(handler func(conn *VirtioSocketConnection, err erro
 	runtime.SetFinalizer(listener, func(self *VirtioSocketListener) {
 		self.Release()
 	})
-	return listener
+	return listener, nil
 }
 
 //export shouldAcceptNewConnectionHandler

--- a/storage.go
+++ b/storage.go
@@ -40,7 +40,14 @@ type DiskImageStorageDeviceAttachment struct {
 //
 // - diskPath is local file URL to the disk image in RAW format.
 // - readOnly if YES, the device attachment is read-only, otherwise the device can write data to the disk image.
+//
+// This is only supported on macOS 11 and newer, ErrUnsupportedOSVersion will
+// be returned on older versions.
 func NewDiskImageStorageDeviceAttachment(diskPath string, readOnly bool) (*DiskImageStorageDeviceAttachment, error) {
+	if macosMajorVersionLessThan(11) {
+		return nil, ErrUnsupportedOSVersion
+	}
+
 	nserr := newNSErrorAsNil()
 	nserrPtr := nserr.Ptr()
 
@@ -94,7 +101,14 @@ type VirtioBlockDeviceConfiguration struct {
 // NewVirtioBlockDeviceConfiguration initialize a VZVirtioBlockDeviceConfiguration with a device attachment.
 //
 // - attachment The storage device attachment. This defines how the virtualized device operates on the host side.
-func NewVirtioBlockDeviceConfiguration(attachment StorageDeviceAttachment) *VirtioBlockDeviceConfiguration {
+//
+// This is only supported on macOS 11 and newer, ErrUnsupportedOSVersion will
+// be returned on older versions.
+func NewVirtioBlockDeviceConfiguration(attachment StorageDeviceAttachment) (*VirtioBlockDeviceConfiguration, error) {
+	if macosMajorVersionLessThan(11) {
+		return nil, ErrUnsupportedOSVersion
+	}
+
 	config := &VirtioBlockDeviceConfiguration{
 		pointer: pointer{
 			ptr: C.newVZVirtioBlockDeviceConfiguration(
@@ -105,5 +119,5 @@ func NewVirtioBlockDeviceConfiguration(attachment StorageDeviceAttachment) *Virt
 	runtime.SetFinalizer(config, func(self *VirtioBlockDeviceConfiguration) {
 		self.Release()
 	})
-	return config
+	return config, nil
 }

--- a/virtualization.go
+++ b/virtualization.go
@@ -100,7 +100,14 @@ type machineStatus struct {
 //
 // A new dispatch queue will create when called this function.
 // Every operation on the virtual machine must be done on that queue. The callbacks and delegate methods are invoked on that queue.
-func NewVirtualMachine(config *VirtualMachineConfiguration) *VirtualMachine {
+//
+// This is only supported on macOS 11 and newer, ErrUnsupportedOSVersion will
+// be returned on older versions.
+func NewVirtualMachine(config *VirtualMachineConfiguration) (*VirtualMachine, error) {
+	if macosMajorVersionLessThan(11) {
+		return nil, ErrUnsupportedOSVersion
+	}
+
 	// should not call Free function for this string.
 	cs := getUUID()
 	dispatchQueue := C.makeDispatchQueue(cs.CString())
@@ -128,7 +135,7 @@ func NewVirtualMachine(config *VirtualMachineConfiguration) *VirtualMachine {
 		releaseDispatch(self.dispatchQueue)
 		self.Release()
 	})
-	return v
+	return v, nil
 }
 
 // SocketDevices return the list of socket devices configured on this virtual machine.
@@ -187,21 +194,37 @@ func (v *VirtualMachine) StateChangedNotify() <-chan VirtualMachineState {
 
 // CanStart returns true if the machine is in a state that can be started.
 func (v *VirtualMachine) CanStart() bool {
+	if macosMajorVersionLessThan(11) {
+		return false
+	}
+
 	return bool(C.vmCanStart(v.Ptr(), v.dispatchQueue))
 }
 
 // CanPause returns true if the machine is in a state that can be paused.
 func (v *VirtualMachine) CanPause() bool {
+	if macosMajorVersionLessThan(11) {
+		return false
+	}
+
 	return bool(C.vmCanPause(v.Ptr(), v.dispatchQueue))
 }
 
 // CanResume returns true if the machine is in a state that can be resumed.
 func (v *VirtualMachine) CanResume() bool {
+	if macosMajorVersionLessThan(11) {
+		return false
+	}
+
 	return (bool)(C.vmCanResume(v.Ptr(), v.dispatchQueue))
 }
 
 // CanRequestStop returns whether the machine is in a state where the guest can be asked to stop.
 func (v *VirtualMachine) CanRequestStop() bool {
+	if macosMajorVersionLessThan(11) {
+		return false
+	}
+
 	return (bool)(C.vmCanRequestStop(v.Ptr(), v.dispatchQueue))
 }
 
@@ -242,7 +265,15 @@ func makeHandler(fn func(error)) (func(error), chan struct{}) {
 //
 // - fn parameter called after the virtual machine has been successfully started or on error.
 // The error parameter passed to the block is null if the start was successful.
+//
+// This is only supported on macOS 11 and newer, on older versions fn will be called immediately
+// with ErrUnsupportedOSVersion.
 func (v *VirtualMachine) Start(fn func(error)) {
+	if macosMajorVersionLessThan(11) {
+		fn(ErrUnsupportedOSVersion)
+		return
+	}
+
 	h, done := makeHandler(fn)
 	handler := cgo.NewHandle(h)
 	defer handler.Delete()
@@ -254,7 +285,15 @@ func (v *VirtualMachine) Start(fn func(error)) {
 //
 // - fn parameter called after the virtual machine has been successfully paused or on error.
 // The error parameter passed to the block is null if the pause was successful.
+//
+// This is only supported on macOS 11 and newer, on older versions fn will be called immediately
+// with ErrUnsupportedOSVersion.
 func (v *VirtualMachine) Pause(fn func(error)) {
+	if macosMajorVersionLessThan(11) {
+		fn(ErrUnsupportedOSVersion)
+		return
+	}
+
 	h, done := makeHandler(fn)
 	handler := cgo.NewHandle(h)
 	defer handler.Delete()
@@ -266,7 +305,15 @@ func (v *VirtualMachine) Pause(fn func(error)) {
 //
 // - fn parameter called after the virtual machine has been successfully resumed or on error.
 // The error parameter passed to the block is null if the resumption was successful.
+//
+// This is only supported on macOS 11 and newer, on older versions fn will be called immediately
+// with ErrUnsupportedOSVersion.
 func (v *VirtualMachine) Resume(fn func(error)) {
+	if macosMajorVersionLessThan(11) {
+		fn(ErrUnsupportedOSVersion)
+		return
+	}
+
 	h, done := makeHandler(fn)
 	handler := cgo.NewHandle(h)
 	defer handler.Delete()
@@ -278,7 +325,14 @@ func (v *VirtualMachine) Resume(fn func(error)) {
 //
 // If returned error is not nil, assigned with the error if the request failed.
 // Returns true if the request was made successfully.
+//
+// This is only supported on macOS 11 and newer, ErrUnsupportedOSVersion will
+// be returned on older versions.
 func (v *VirtualMachine) RequestStop() (bool, error) {
+	if macosMajorVersionLessThan(11) {
+		return false, ErrUnsupportedOSVersion
+	}
+
 	nserr := newNSErrorAsNil()
 	nserrPtr := nserr.Ptr()
 	ret := (bool)(C.requestStopVirtualMachine(v.Ptr(), v.dispatchQueue, &nserrPtr))

--- a/virtualization.h
+++ b/virtualization.h
@@ -21,7 +21,7 @@ bool shouldAcceptNewConnectionHandler(void *listener, void *connection, void *so
 
 /* VZVirtioSocketListener */
 @interface VZVirtioSocketListenerDelegateImpl : NSObject <VZVirtioSocketListenerDelegate>
-- (BOOL)listener:(VZVirtioSocketListener *)listener shouldAcceptNewConnection:(VZVirtioSocketConnection *)connection fromSocketDevice:(VZVirtioSocketDevice *)socketDevice;
+- (BOOL)listener:(void *)listener shouldAcceptNewConnection:(void *)connection fromSocketDevice:(void *)socketDevice;
 @end
 
 /* BootLoader */

--- a/virtualization.h
+++ b/virtualization.h
@@ -21,7 +21,7 @@ bool shouldAcceptNewConnectionHandler(void *listener, void *connection, void *so
 
 /* VZVirtioSocketListener */
 @interface VZVirtioSocketListenerDelegateImpl : NSObject <VZVirtioSocketListenerDelegate>
-- (BOOL)listener:(void *)listener shouldAcceptNewConnection:(void *)connection fromSocketDevice:(void *)socketDevice;
+- (BOOL)listener:(VZVirtioSocketListener *)listener shouldAcceptNewConnection:(VZVirtioSocketConnection *)connection fromSocketDevice:(VZVirtioSocketDevice *)socketDevice;
 @end
 
 /* BootLoader */

--- a/virtualization.m
+++ b/virtualization.m
@@ -280,7 +280,12 @@ void setSerialPortsVZVirtualMachineConfiguration(void *config,
 void setSocketDevicesVZVirtualMachineConfiguration(void *config,
     void *socketDevices)
 {
-    [(VZVirtualMachineConfiguration *)config setSocketDevices:[(NSMutableArray *)socketDevices copy]];
+    if (@available(macOS 11, *)) {
+        [(VZVirtualMachineConfiguration *)config setSocketDevices:[(NSMutableArray *)socketDevices copy]];
+        return;
+    }
+
+    RAISE_UNSUPPORTED_MACOS_EXCEPTION();
 }
 
 /*!
@@ -717,7 +722,11 @@ void *newVZVirtioTraditionalMemoryBalloonDeviceConfiguration()
  */
 void *newVZVirtioSocketDeviceConfiguration()
 {
-    return [[VZVirtioSocketDeviceConfiguration alloc] init];
+    if (@available(macOS 11, *)) {
+        return [[VZVirtioSocketDeviceConfiguration alloc] init];
+    }
+
+    RAISE_UNSUPPORTED_MACOS_EXCEPTION();
 }
 
 /*!
@@ -731,9 +740,13 @@ void *newVZVirtioSocketDeviceConfiguration()
  */
 void *newVZVirtioSocketListener()
 {
-    VZVirtioSocketListener *ret = [[VZVirtioSocketListener alloc] init];
-    [ret setDelegate:[[VZVirtioSocketListenerDelegateImpl alloc] init]];
-    return ret;
+    if (@available(macOS 11, *)) {
+        VZVirtioSocketListener *ret = [[VZVirtioSocketListener alloc] init];
+        [ret setDelegate:[[VZVirtioSocketListenerDelegateImpl alloc] init]];
+        return ret;
+    }
+
+    RAISE_UNSUPPORTED_MACOS_EXCEPTION();
 }
 
 /*!
@@ -747,9 +760,14 @@ void *newVZVirtioSocketListener()
  */
 void VZVirtioSocketDevice_setSocketListenerForPort(void *socketDevice, void *vmQueue, void *listener, uint32_t port)
 {
-    dispatch_sync((dispatch_queue_t)vmQueue, ^{
-        [(VZVirtioSocketDevice *)socketDevice setSocketListener:(VZVirtioSocketListener *)listener forPort:port];
-    });
+    if (@available(macOS 11, *)) {
+        dispatch_sync((dispatch_queue_t)vmQueue, ^{
+            [(VZVirtioSocketDevice *)socketDevice setSocketListener:(VZVirtioSocketListener *)listener forPort:port];
+        });
+        return;
+    }
+
+    RAISE_UNSUPPORTED_MACOS_EXCEPTION();
 }
 
 /*!
@@ -759,9 +777,14 @@ void VZVirtioSocketDevice_setSocketListenerForPort(void *socketDevice, void *vmQ
  */
 void VZVirtioSocketDevice_removeSocketListenerForPort(void *socketDevice, void *vmQueue, uint32_t port)
 {
-    dispatch_sync((dispatch_queue_t)vmQueue, ^{
-        [(VZVirtioSocketDevice *)socketDevice removeSocketListenerForPort:port];
-    });
+    if (@available(macOS 11, *)) {
+        dispatch_sync((dispatch_queue_t)vmQueue, ^{
+            [(VZVirtioSocketDevice *)socketDevice removeSocketListenerForPort:port];
+        });
+        return;
+    }
+
+    RAISE_UNSUPPORTED_MACOS_EXCEPTION();
 }
 
 /*!
@@ -773,21 +796,30 @@ void VZVirtioSocketDevice_removeSocketListenerForPort(void *socketDevice, void *
  */
 void VZVirtioSocketDevice_connectToPort(void *socketDevice, void *vmQueue, uint32_t port, void *cgoHandlerPtr)
 {
-    dispatch_sync((dispatch_queue_t)vmQueue, ^{
-        [(VZVirtioSocketDevice *)socketDevice connectToPort:port
-                                          completionHandler:^(VZVirtioSocketConnection *connection, NSError *err) {
-                                              connectionHandler(connection, err, cgoHandlerPtr);
-                                          }];
-    });
+    if (@available(macOS 11, *)) {
+        dispatch_sync((dispatch_queue_t)vmQueue, ^{
+            [(VZVirtioSocketDevice *)socketDevice connectToPort:port
+                                              completionHandler:^(VZVirtioSocketConnection *connection, NSError *err) {
+                                                  connectionHandler(connection, err, cgoHandlerPtr);
+                                              }];
+        });
+        return;
+    }
+
+    RAISE_UNSUPPORTED_MACOS_EXCEPTION();
 }
 
 VZVirtioSocketConnectionFlat convertVZVirtioSocketConnection2Flat(void *connection)
 {
-    VZVirtioSocketConnectionFlat ret;
-    ret.sourcePort = [(VZVirtioSocketConnection *)connection sourcePort];
-    ret.destinationPort = [(VZVirtioSocketConnection *)connection destinationPort];
-    ret.fileDescriptor = [(VZVirtioSocketConnection *)connection fileDescriptor];
-    return ret;
+    if (@available(macOS 11, *)) {
+        VZVirtioSocketConnectionFlat ret;
+        ret.sourcePort = [(VZVirtioSocketConnection *)connection sourcePort];
+        ret.destinationPort = [(VZVirtioSocketConnection *)connection destinationPort];
+        ret.fileDescriptor = [(VZVirtioSocketConnection *)connection fileDescriptor];
+        return ret;
+    }
+
+    RAISE_UNSUPPORTED_MACOS_EXCEPTION();
 }
 
 /*!
@@ -825,7 +857,11 @@ void *newVZVirtualMachineWithDispatchQueue(void *config, void *queue, void *stat
  */
 void *VZVirtualMachine_socketDevices(void *machine)
 {
-    return [(VZVirtualMachine *)machine socketDevices]; // NSArray<VZSocketDevice *>
+    if (@available(macOS 11, *)) {
+        return [(VZVirtualMachine *)machine socketDevices]; // NSArray<VZSocketDevice *>
+    }
+
+    RAISE_UNSUPPORTED_MACOS_EXCEPTION();
 }
 
 /*!

--- a/virtualization.m
+++ b/virtualization.m
@@ -801,17 +801,21 @@ VZVirtioSocketConnectionFlat convertVZVirtioSocketConnection2Flat(void *connecti
  */
 void *newVZVirtualMachineWithDispatchQueue(void *config, void *queue, void *statusHandler)
 {
-    VZVirtualMachine *vm = [[VZVirtualMachine alloc]
-        initWithConfiguration:(VZVirtualMachineConfiguration *)config
-                        queue:(dispatch_queue_t)queue];
-    @autoreleasepool {
-        Observer *o = [[Observer alloc] init];
-        [vm addObserver:o
-             forKeyPath:@"state"
-                options:NSKeyValueObservingOptionNew
-                context:statusHandler];
+    if (@available(macOS 11, *)) {
+        VZVirtualMachine *vm = [[VZVirtualMachine alloc]
+            initWithConfiguration:(VZVirtualMachineConfiguration *)config
+                            queue:(dispatch_queue_t)queue];
+        @autoreleasepool {
+            Observer *o = [[Observer alloc] init];
+            [vm addObserver:o
+                 forKeyPath:@"state"
+                    options:NSKeyValueObservingOptionNew
+                    context:statusHandler];
+        }
+        return vm;
     }
-    return vm;
+
+    RAISE_UNSUPPORTED_MACOS_EXCEPTION();
 }
 
 /*!
@@ -1009,11 +1013,15 @@ void *newVZUSBKeyboardConfiguration()
  */
 bool requestStopVirtualMachine(void *machine, void *queue, void **error)
 {
-    __block BOOL ret;
-    dispatch_sync((dispatch_queue_t)queue, ^{
-        ret = [(VZVirtualMachine *)machine requestStopWithError:(NSError *_Nullable *_Nullable)error];
-    });
-    return (bool)ret;
+    if (@available(macOS 11, *)) {
+        __block BOOL ret;
+        dispatch_sync((dispatch_queue_t)queue, ^{
+            ret = [(VZVirtualMachine *)machine requestStopWithError:(NSError *_Nullable *_Nullable)error];
+        });
+        return (bool)ret;
+    }
+
+    RAISE_UNSUPPORTED_MACOS_EXCEPTION();
 }
 
 void *makeDispatchQueue(const char *label)
@@ -1026,29 +1034,44 @@ void *makeDispatchQueue(const char *label)
 
 void startWithCompletionHandler(void *machine, void *queue, void *completionHandler)
 {
-    dispatch_sync((dispatch_queue_t)queue, ^{
-        [(VZVirtualMachine *)machine startWithCompletionHandler:^(NSError *err) {
-            virtualMachineCompletionHandler(completionHandler, err);
-        }];
-    });
+    if (@available(macOS 11, *)) {
+        dispatch_sync((dispatch_queue_t)queue, ^{
+            [(VZVirtualMachine *)machine startWithCompletionHandler:^(NSError *err) {
+                virtualMachineCompletionHandler(completionHandler, err);
+            }];
+        });
+        return;
+    }
+
+    RAISE_UNSUPPORTED_MACOS_EXCEPTION();
 }
 
 void pauseWithCompletionHandler(void *machine, void *queue, void *completionHandler)
 {
-    dispatch_sync((dispatch_queue_t)queue, ^{
-        [(VZVirtualMachine *)machine pauseWithCompletionHandler:^(NSError *err) {
-            virtualMachineCompletionHandler(completionHandler, err);
-        }];
-    });
+    if (@available(macOS 11, *)) {
+        dispatch_sync((dispatch_queue_t)queue, ^{
+            [(VZVirtualMachine *)machine pauseWithCompletionHandler:^(NSError *err) {
+                virtualMachineCompletionHandler(completionHandler, err);
+            }];
+        });
+        return;
+    }
+
+    RAISE_UNSUPPORTED_MACOS_EXCEPTION();
 }
 
 void resumeWithCompletionHandler(void *machine, void *queue, void *completionHandler)
 {
-    dispatch_sync((dispatch_queue_t)queue, ^{
-        [(VZVirtualMachine *)machine resumeWithCompletionHandler:^(NSError *err) {
-            virtualMachineCompletionHandler(completionHandler, err);
-        }];
-    });
+    if (@available(macOS 11, *)) {
+        dispatch_sync((dispatch_queue_t)queue, ^{
+            [(VZVirtualMachine *)machine resumeWithCompletionHandler:^(NSError *err) {
+                virtualMachineCompletionHandler(completionHandler, err);
+            }];
+        });
+        return;
+    }
+
+    RAISE_UNSUPPORTED_MACOS_EXCEPTION();
 }
 
 void stopWithCompletionHandler(void *machine, void *queue, void *completionHandler)
@@ -1068,38 +1091,54 @@ void stopWithCompletionHandler(void *machine, void *queue, void *completionHandl
 // TODO(codehex): use KVO
 bool vmCanStart(void *machine, void *queue)
 {
-    __block BOOL result;
-    dispatch_sync((dispatch_queue_t)queue, ^{
-        result = ((VZVirtualMachine *)machine).canStart;
-    });
-    return (bool)result;
+    if (@available(macOS 11, *)) {
+        __block BOOL result;
+        dispatch_sync((dispatch_queue_t)queue, ^{
+            result = ((VZVirtualMachine *)machine).canStart;
+        });
+        return (bool)result;
+    }
+
+    RAISE_UNSUPPORTED_MACOS_EXCEPTION();
 }
 
 bool vmCanPause(void *machine, void *queue)
 {
-    __block BOOL result;
-    dispatch_sync((dispatch_queue_t)queue, ^{
-        result = ((VZVirtualMachine *)machine).canPause;
-    });
-    return (bool)result;
+    if (@available(macOS 11, *)) {
+        __block BOOL result;
+        dispatch_sync((dispatch_queue_t)queue, ^{
+            result = ((VZVirtualMachine *)machine).canPause;
+        });
+        return (bool)result;
+    }
+
+    RAISE_UNSUPPORTED_MACOS_EXCEPTION();
 }
 
 bool vmCanResume(void *machine, void *queue)
 {
-    __block BOOL result;
-    dispatch_sync((dispatch_queue_t)queue, ^{
-        result = ((VZVirtualMachine *)machine).canResume;
-    });
-    return (bool)result;
+    if (@available(macOS 11, *)) {
+        __block BOOL result;
+        dispatch_sync((dispatch_queue_t)queue, ^{
+            result = ((VZVirtualMachine *)machine).canResume;
+        });
+        return (bool)result;
+    }
+
+    RAISE_UNSUPPORTED_MACOS_EXCEPTION();
 }
 
 bool vmCanRequestStop(void *machine, void *queue)
 {
-    __block BOOL result;
-    dispatch_sync((dispatch_queue_t)queue, ^{
-        result = ((VZVirtualMachine *)machine).canRequestStop;
-    });
-    return (bool)result;
+    if (@available(macOS 11, *)) {
+        __block BOOL result;
+        dispatch_sync((dispatch_queue_t)queue, ^{
+            result = ((VZVirtualMachine *)machine).canRequestStop;
+        });
+        return (bool)result;
+    }
+
+    RAISE_UNSUPPORTED_MACOS_EXCEPTION();
 }
 
 bool vmCanStop(void *machine, void *queue)

--- a/virtualization.m
+++ b/virtualization.m
@@ -42,9 +42,13 @@ char *copyCString(NSString *nss)
 @end
 
 @implementation VZVirtioSocketListenerDelegateImpl
-- (BOOL)listener:(VZVirtioSocketListener *)listener shouldAcceptNewConnection:(VZVirtioSocketConnection *)connection fromSocketDevice:(VZVirtioSocketDevice *)socketDevice;
+- (BOOL)listener:(void *)listener shouldAcceptNewConnection:(void *)connection fromSocketDevice:(void *)socketDevice;
 {
-    return (BOOL)shouldAcceptNewConnectionHandler(listener, connection, socketDevice);
+    if (@available(macOS 11, *)) {
+        return (BOOL)shouldAcceptNewConnectionHandler((VZVirtioSocketListener *)listener, (VZVirtioSocketConnection *)connection, (VZVirtioSocketDevice *)socketDevice);
+    }
+
+    RAISE_UNSUPPORTED_MACOS_EXCEPTION();
 }
 @end
 

--- a/virtualization.m
+++ b/virtualization.m
@@ -290,7 +290,12 @@ void setSocketDevicesVZVirtualMachineConfiguration(void *config,
 void setStorageDevicesVZVirtualMachineConfiguration(void *config,
     void *storageDevices)
 {
-    [(VZVirtualMachineConfiguration *)config setStorageDevices:[(NSMutableArray *)storageDevices copy]];
+    if (@available(macOS 11, *)) {
+        [(VZVirtualMachineConfiguration *)config setStorageDevices:[(NSMutableArray *)storageDevices copy]];
+        return;
+    }
+
+    RAISE_UNSUPPORTED_MACOS_EXCEPTION();
 }
 /*!
  @abstract List of directory sharing devices. Empty by default.
@@ -658,7 +663,11 @@ void *newVZVirtioEntropyDeviceConfiguration()
  */
 void *newVZVirtioBlockDeviceConfiguration(void *attachment)
 {
-    return [[VZVirtioBlockDeviceConfiguration alloc] initWithAttachment:(VZStorageDeviceAttachment *)attachment];
+    if (@available(macOS 11, *)) {
+        return [[VZVirtioBlockDeviceConfiguration alloc] initWithAttachment:(VZStorageDeviceAttachment *)attachment];
+    }
+
+    RAISE_UNSUPPORTED_MACOS_EXCEPTION();
 }
 
 /*!
@@ -670,12 +679,16 @@ void *newVZVirtioBlockDeviceConfiguration(void *attachment)
  */
 void *newVZDiskImageStorageDeviceAttachment(const char *diskPath, bool readOnly, void **error)
 {
-    NSString *diskPathNSString = [NSString stringWithUTF8String:diskPath];
-    NSURL *diskURL = [NSURL fileURLWithPath:diskPathNSString];
-    return [[VZDiskImageStorageDeviceAttachment alloc]
-        initWithURL:diskURL
-           readOnly:(BOOL)readOnly
-              error:(NSError *_Nullable *_Nullable)error];
+    if (@available(macOS 11, *)) {
+        NSString *diskPathNSString = [NSString stringWithUTF8String:diskPath];
+        NSURL *diskURL = [NSURL fileURLWithPath:diskPathNSString];
+        return [[VZDiskImageStorageDeviceAttachment alloc]
+            initWithURL:diskURL
+               readOnly:(BOOL)readOnly
+                  error:(NSError *_Nullable *_Nullable)error];
+    }
+
+    RAISE_UNSUPPORTED_MACOS_EXCEPTION();
 }
 
 /*!

--- a/virtualization.m
+++ b/virtualization.m
@@ -220,7 +220,12 @@ void *newVZVirtualMachineConfiguration(void *bootLoaderPtr,
 void setEntropyDevicesVZVirtualMachineConfiguration(void *config,
     void *entropyDevices)
 {
-    [(VZVirtualMachineConfiguration *)config setEntropyDevices:[(NSMutableArray *)entropyDevices copy]];
+    if (@available(macOS 11, *)) {
+        [(VZVirtualMachineConfiguration *)config setEntropyDevices:[(NSMutableArray *)entropyDevices copy]];
+        return;
+    }
+
+    RAISE_UNSUPPORTED_MACOS_EXCEPTION();
 }
 
 /*!
@@ -596,7 +601,11 @@ void *newVZVirtioNetworkDeviceConfiguration(void *attachment)
 */
 void *newVZVirtioEntropyDeviceConfiguration()
 {
-    return [[VZVirtioEntropyDeviceConfiguration alloc] init];
+    if (@available(macOS 11, *)) {
+        return [[VZVirtioEntropyDeviceConfiguration alloc] init];
+    }
+
+    RAISE_UNSUPPORTED_MACOS_EXCEPTION();
 }
 
 /*!

--- a/virtualization.m
+++ b/virtualization.m
@@ -116,8 +116,12 @@ void setInitialRamdiskURLVZLinuxBootLoader(void *bootLoaderPtr, const char *ramd
  */
 bool validateVZVirtualMachineConfiguration(void *config, void **error)
 {
-    return (bool)[(VZVirtualMachineConfiguration *)config
-        validateWithError:(NSError *_Nullable *_Nullable)error];
+    if (@available(macOS 11, *)) {
+        return (bool)[(VZVirtualMachineConfiguration *)config
+            validateWithError:(NSError *_Nullable *_Nullable)error];
+    }
+
+    RAISE_UNSUPPORTED_MACOS_EXCEPTION();
 }
 
 /*!
@@ -126,7 +130,11 @@ bool validateVZVirtualMachineConfiguration(void *config, void **error)
  */
 unsigned long long minimumAllowedMemorySizeVZVirtualMachineConfiguration()
 {
-    return (unsigned long long)[VZVirtualMachineConfiguration minimumAllowedMemorySize];
+    if (@available(macOS 11, *)) {
+        return (unsigned long long)[VZVirtualMachineConfiguration minimumAllowedMemorySize];
+    }
+
+    RAISE_UNSUPPORTED_MACOS_EXCEPTION();
 }
 
 /*!
@@ -135,7 +143,11 @@ unsigned long long minimumAllowedMemorySizeVZVirtualMachineConfiguration()
  */
 unsigned long long maximumAllowedMemorySizeVZVirtualMachineConfiguration()
 {
-    return (unsigned long long)[VZVirtualMachineConfiguration maximumAllowedMemorySize];
+    if (@available(macOS 11, *)) {
+        return (unsigned long long)[VZVirtualMachineConfiguration maximumAllowedMemorySize];
+    }
+
+    RAISE_UNSUPPORTED_MACOS_EXCEPTION();
 }
 
 /*!
@@ -144,7 +156,11 @@ unsigned long long maximumAllowedMemorySizeVZVirtualMachineConfiguration()
  */
 unsigned int minimumAllowedCPUCountVZVirtualMachineConfiguration()
 {
-    return (unsigned int)[VZVirtualMachineConfiguration minimumAllowedCPUCount];
+    if (@available(macOS 11, *)) {
+        return (unsigned int)[VZVirtualMachineConfiguration minimumAllowedCPUCount];
+    }
+
+    RAISE_UNSUPPORTED_MACOS_EXCEPTION();
 }
 
 /*!
@@ -153,7 +169,11 @@ unsigned int minimumAllowedCPUCountVZVirtualMachineConfiguration()
  */
 unsigned int maximumAllowedCPUCountVZVirtualMachineConfiguration()
 {
-    return (unsigned int)[VZVirtualMachineConfiguration maximumAllowedCPUCount];
+    if (@available(macOS 11, *)) {
+        return (unsigned int)[VZVirtualMachineConfiguration maximumAllowedCPUCount];
+    }
+
+    RAISE_UNSUPPORTED_MACOS_EXCEPTION();
 }
 
 /*!
@@ -182,11 +202,15 @@ void *newVZVirtualMachineConfiguration(void *bootLoaderPtr,
     unsigned int CPUCount,
     unsigned long long memorySize)
 {
-    VZVirtualMachineConfiguration *config = [[VZVirtualMachineConfiguration alloc] init];
-    [config setBootLoader:(VZLinuxBootLoader *)bootLoaderPtr];
-    [config setCPUCount:(NSUInteger)CPUCount];
-    [config setMemorySize:memorySize];
-    return config;
+    if (@available(macOS 11, *)) {
+        VZVirtualMachineConfiguration *config = [[VZVirtualMachineConfiguration alloc] init];
+        [config setBootLoader:(VZLinuxBootLoader *)bootLoaderPtr];
+        [config setCPUCount:(NSUInteger)CPUCount];
+        [config setMemorySize:memorySize];
+        return config;
+    }
+
+    RAISE_UNSUPPORTED_MACOS_EXCEPTION();
 }
 
 /*!

--- a/virtualization.m
+++ b/virtualization.m
@@ -54,13 +54,17 @@ char *copyCString(NSString *nss)
 */
 void *newVZLinuxBootLoader(const char *kernelPath)
 {
-    VZLinuxBootLoader *ret;
-    @autoreleasepool {
-        NSString *kernelPathNSString = [NSString stringWithUTF8String:kernelPath];
-        NSURL *kernelURL = [NSURL fileURLWithPath:kernelPathNSString];
-        ret = [[VZLinuxBootLoader alloc] initWithKernelURL:kernelURL];
+    if (@available(macOS 11, *)) {
+        VZLinuxBootLoader *ret;
+        @autoreleasepool {
+            NSString *kernelPathNSString = [NSString stringWithUTF8String:kernelPath];
+            NSURL *kernelURL = [NSURL fileURLWithPath:kernelPathNSString];
+            ret = [[VZLinuxBootLoader alloc] initWithKernelURL:kernelURL];
+        }
+        return ret;
     }
-    return ret;
+
+    RAISE_UNSUPPORTED_MACOS_EXCEPTION();
 }
 
 /*!
@@ -71,11 +75,16 @@ void *newVZLinuxBootLoader(const char *kernelPath)
  */
 void setCommandLineVZLinuxBootLoader(void *bootLoaderPtr, const char *commandLine)
 {
-    VZLinuxBootLoader *bootLoader = (VZLinuxBootLoader *)bootLoaderPtr;
-    @autoreleasepool {
-        NSString *commandLineNSString = [NSString stringWithUTF8String:commandLine];
-        [bootLoader setCommandLine:commandLineNSString];
+    if (@available(macOS 11, *)) {
+        VZLinuxBootLoader *bootLoader = (VZLinuxBootLoader *)bootLoaderPtr;
+        @autoreleasepool {
+            NSString *commandLineNSString = [NSString stringWithUTF8String:commandLine];
+            [bootLoader setCommandLine:commandLineNSString];
+        }
+        return;
     }
+
+    RAISE_UNSUPPORTED_MACOS_EXCEPTION();
 }
 
 /*!
@@ -86,12 +95,17 @@ void setCommandLineVZLinuxBootLoader(void *bootLoaderPtr, const char *commandLin
  */
 void setInitialRamdiskURLVZLinuxBootLoader(void *bootLoaderPtr, const char *ramdiskPath)
 {
-    VZLinuxBootLoader *bootLoader = (VZLinuxBootLoader *)bootLoaderPtr;
-    @autoreleasepool {
-        NSString *ramdiskPathNSString = [NSString stringWithUTF8String:ramdiskPath];
-        NSURL *ramdiskURL = [NSURL fileURLWithPath:ramdiskPathNSString];
-        [bootLoader setInitialRamdiskURL:ramdiskURL];
+    if (@available(macOS 11, *)) {
+        VZLinuxBootLoader *bootLoader = (VZLinuxBootLoader *)bootLoaderPtr;
+        @autoreleasepool {
+            NSString *ramdiskPathNSString = [NSString stringWithUTF8String:ramdiskPath];
+            NSURL *ramdiskURL = [NSURL fileURLWithPath:ramdiskPathNSString];
+            [bootLoader setInitialRamdiskURL:ramdiskURL];
+        }
+        return;
     }
+
+    RAISE_UNSUPPORTED_MACOS_EXCEPTION();
 }
 
 /*!

--- a/virtualization.m
+++ b/virtualization.m
@@ -235,7 +235,12 @@ void setEntropyDevicesVZVirtualMachineConfiguration(void *config,
 void setMemoryBalloonDevicesVZVirtualMachineConfiguration(void *config,
     void *memoryBalloonDevices)
 {
-    [(VZVirtualMachineConfiguration *)config setMemoryBalloonDevices:[(NSMutableArray *)memoryBalloonDevices copy]];
+    if (@available(macOS 11, *)) {
+        [(VZVirtualMachineConfiguration *)config setMemoryBalloonDevices:[(NSMutableArray *)memoryBalloonDevices copy]];
+        return;
+    }
+
+    RAISE_UNSUPPORTED_MACOS_EXCEPTION();
 }
 
 /*!
@@ -644,7 +649,11 @@ void *newVZDiskImageStorageDeviceAttachment(const char *diskPath, bool readOnly,
  */
 void *newVZVirtioTraditionalMemoryBalloonDeviceConfiguration()
 {
-    return [[VZVirtioTraditionalMemoryBalloonDeviceConfiguration alloc] init];
+    if (@available(macOS 11, *)) {
+        return [[VZVirtioTraditionalMemoryBalloonDeviceConfiguration alloc] init];
+    }
+
+    RAISE_UNSUPPORTED_MACOS_EXCEPTION();
 }
 
 /*!

--- a/virtualization.m
+++ b/virtualization.m
@@ -250,7 +250,12 @@ void setMemoryBalloonDevicesVZVirtualMachineConfiguration(void *config,
 void setNetworkDevicesVZVirtualMachineConfiguration(void *config,
     void *networkDevices)
 {
-    [(VZVirtualMachineConfiguration *)config setNetworkDevices:[(NSMutableArray *)networkDevices copy]];
+    if (@available(macOS 11, *)) {
+        [(VZVirtualMachineConfiguration *)config setNetworkDevices:[(NSMutableArray *)networkDevices copy]];
+        return;
+    }
+
+    RAISE_UNSUPPORTED_MACOS_EXCEPTION();
 }
 
 /*!
@@ -533,7 +538,11 @@ void *newVZVirtioConsoleDeviceSerialPortConfiguration(void *attachment)
  */
 void *newVZBridgedNetworkDeviceAttachment(void *networkInterface)
 {
-    return [[VZBridgedNetworkDeviceAttachment alloc] initWithInterface:(VZBridgedNetworkInterface *)networkInterface];
+    if (@available(macOS 11, *)) {
+        return [[VZBridgedNetworkDeviceAttachment alloc] initWithInterface:(VZBridgedNetworkInterface *)networkInterface];
+    }
+
+    RAISE_UNSUPPORTED_MACOS_EXCEPTION();
 }
 
 /*!
@@ -546,7 +555,11 @@ void *newVZBridgedNetworkDeviceAttachment(void *networkInterface)
  */
 void *newVZNATNetworkDeviceAttachment()
 {
-    return [[VZNATNetworkDeviceAttachment alloc] init];
+    if (@available(macOS 11, *)) {
+        return [[VZNATNetworkDeviceAttachment alloc] init];
+    }
+
+    RAISE_UNSUPPORTED_MACOS_EXCEPTION();
 }
 
 /*!
@@ -562,12 +575,16 @@ void *newVZNATNetworkDeviceAttachment()
  */
 void *newVZFileHandleNetworkDeviceAttachment(int fileDescriptor)
 {
-    VZFileHandleNetworkDeviceAttachment *ret;
-    @autoreleasepool {
-        NSFileHandle *fileHandle = [[NSFileHandle alloc] initWithFileDescriptor:fileDescriptor];
-        ret = [[VZFileHandleNetworkDeviceAttachment alloc] initWithFileHandle:fileHandle];
+    if (@available(macOS 11, *)) {
+        VZFileHandleNetworkDeviceAttachment *ret;
+        @autoreleasepool {
+            NSFileHandle *fileHandle = [[NSFileHandle alloc] initWithFileDescriptor:fileDescriptor];
+            ret = [[VZFileHandleNetworkDeviceAttachment alloc] initWithFileHandle:fileHandle];
+        }
+        return ret;
     }
-    return ret;
+
+    RAISE_UNSUPPORTED_MACOS_EXCEPTION();
 }
 
 /*!
@@ -595,9 +612,13 @@ void *newVZFileHandleNetworkDeviceAttachment(int fileDescriptor)
  */
 void *newVZVirtioNetworkDeviceConfiguration(void *attachment)
 {
-    VZVirtioNetworkDeviceConfiguration *config = [[VZVirtioNetworkDeviceConfiguration alloc] init];
-    [config setAttachment:(VZNetworkDeviceAttachment *)attachment];
-    return config;
+    if (@available(macOS 11, *)) {
+        VZVirtioNetworkDeviceConfiguration *config = [[VZVirtioNetworkDeviceConfiguration alloc] init];
+        [config setAttachment:(VZNetworkDeviceAttachment *)attachment];
+        return config;
+    }
+
+    RAISE_UNSUPPORTED_MACOS_EXCEPTION();
 }
 
 /*!
@@ -784,12 +805,16 @@ void *VZVirtualMachine_socketDevices(void *machine)
  */
 void *newVZMACAddress(const char *macAddress)
 {
-    VZMACAddress *ret;
-    @autoreleasepool {
-        NSString *str = [NSString stringWithUTF8String:macAddress];
-        ret = [[VZMACAddress alloc] initWithString:str];
+    if (@available(macOS 11, *)) {
+        VZMACAddress *ret;
+        @autoreleasepool {
+            NSString *str = [NSString stringWithUTF8String:macAddress];
+            ret = [[VZMACAddress alloc] initWithString:str];
+        }
+        return ret;
     }
-    return ret;
+
+    RAISE_UNSUPPORTED_MACOS_EXCEPTION();
 }
 
 /*!
@@ -798,7 +823,11 @@ void *newVZMACAddress(const char *macAddress)
  */
 void *newRandomLocallyAdministeredVZMACAddress()
 {
-    return [VZMACAddress randomLocallyAdministeredAddress];
+    if (@available(macOS 11, *)) {
+        return [VZMACAddress randomLocallyAdministeredAddress];
+    }
+
+    RAISE_UNSUPPORTED_MACOS_EXCEPTION();
 }
 
 /*!
@@ -806,7 +835,12 @@ void *newRandomLocallyAdministeredVZMACAddress()
  */
 void setNetworkDevicesVZMACAddress(void *config, void *macAddress)
 {
-    [(VZNetworkDeviceConfiguration *)config setMACAddress:[(VZMACAddress *)macAddress copy]];
+    if (@available(macOS 11, *)) {
+        [(VZNetworkDeviceConfiguration *)config setMACAddress:[(VZMACAddress *)macAddress copy]];
+        return;
+    }
+
+    RAISE_UNSUPPORTED_MACOS_EXCEPTION();
 }
 
 /*!
@@ -819,7 +853,11 @@ void setNetworkDevicesVZMACAddress(void *config, void *macAddress)
  */
 const char *getVZMACAddressString(void *macAddress)
 {
-    return [[(VZMACAddress *)macAddress string] UTF8String];
+    if (@available(macOS 11, *)) {
+        return [[(VZMACAddress *)macAddress string] UTF8String];
+    }
+
+    RAISE_UNSUPPORTED_MACOS_EXCEPTION();
 }
 
 /*!

--- a/virtualization.m
+++ b/virtualization.m
@@ -265,7 +265,12 @@ void setNetworkDevicesVZVirtualMachineConfiguration(void *config,
 void setSerialPortsVZVirtualMachineConfiguration(void *config,
     void *serialPorts)
 {
-    [(VZVirtualMachineConfiguration *)config setSerialPorts:[(NSMutableArray *)serialPorts copy]];
+    if (@available(macOS 11, *)) {
+        [(VZVirtualMachineConfiguration *)config setSerialPorts:[(NSMutableArray *)serialPorts copy]];
+        return;
+    }
+
+    RAISE_UNSUPPORTED_MACOS_EXCEPTION();
 }
 
 /*!
@@ -473,15 +478,19 @@ void *newVZGenericPlatformConfiguration()
 */
 void *newVZFileHandleSerialPortAttachment(int readFileDescriptor, int writeFileDescriptor)
 {
-    VZFileHandleSerialPortAttachment *ret;
-    @autoreleasepool {
-        NSFileHandle *fileHandleForReading = [[NSFileHandle alloc] initWithFileDescriptor:readFileDescriptor];
-        NSFileHandle *fileHandleForWriting = [[NSFileHandle alloc] initWithFileDescriptor:writeFileDescriptor];
-        ret = [[VZFileHandleSerialPortAttachment alloc]
-            initWithFileHandleForReading:fileHandleForReading
-                    fileHandleForWriting:fileHandleForWriting];
+    if (@available(macOS 11, *)) {
+        VZFileHandleSerialPortAttachment *ret;
+        @autoreleasepool {
+            NSFileHandle *fileHandleForReading = [[NSFileHandle alloc] initWithFileDescriptor:readFileDescriptor];
+            NSFileHandle *fileHandleForWriting = [[NSFileHandle alloc] initWithFileDescriptor:writeFileDescriptor];
+            ret = [[VZFileHandleSerialPortAttachment alloc]
+                initWithFileHandleForReading:fileHandleForReading
+                        fileHandleForWriting:fileHandleForWriting];
+        }
+        return ret;
     }
-    return ret;
+
+    RAISE_UNSUPPORTED_MACOS_EXCEPTION();
 }
 
 /*!
@@ -494,16 +503,20 @@ void *newVZFileHandleSerialPortAttachment(int readFileDescriptor, int writeFileD
  */
 void *newVZFileSerialPortAttachment(const char *filePath, bool shouldAppend, void **error)
 {
-    VZFileSerialPortAttachment *ret;
-    @autoreleasepool {
-        NSString *filePathNSString = [NSString stringWithUTF8String:filePath];
-        NSURL *fileURL = [NSURL fileURLWithPath:filePathNSString];
-        ret = [[VZFileSerialPortAttachment alloc]
-            initWithURL:fileURL
-                 append:(BOOL)shouldAppend
-                  error:(NSError *_Nullable *_Nullable)error];
+    if (@available(macOS 11, *)) {
+        VZFileSerialPortAttachment *ret;
+        @autoreleasepool {
+            NSString *filePathNSString = [NSString stringWithUTF8String:filePath];
+            NSURL *fileURL = [NSURL fileURLWithPath:filePathNSString];
+            ret = [[VZFileSerialPortAttachment alloc]
+                initWithURL:fileURL
+                     append:(BOOL)shouldAppend
+                      error:(NSError *_Nullable *_Nullable)error];
+        }
+        return ret;
     }
-    return ret;
+
+    RAISE_UNSUPPORTED_MACOS_EXCEPTION();
 }
 
 /*!
@@ -516,9 +529,13 @@ void *newVZFileSerialPortAttachment(const char *filePath, bool shouldAppend, voi
  */
 void *newVZVirtioConsoleDeviceSerialPortConfiguration(void *attachment)
 {
-    VZVirtioConsoleDeviceSerialPortConfiguration *config = [[VZVirtioConsoleDeviceSerialPortConfiguration alloc] init];
-    [config setAttachment:(VZSerialPortAttachment *)attachment];
-    return config;
+    if (@available(macOS 11, *)) {
+        VZVirtioConsoleDeviceSerialPortConfiguration *config = [[VZVirtioConsoleDeviceSerialPortConfiguration alloc] init];
+        [config setAttachment:(VZSerialPortAttachment *)attachment];
+        return config;
+    }
+
+    RAISE_UNSUPPORTED_MACOS_EXCEPTION();
 }
 
 /*!

--- a/virtualization.m
+++ b/virtualization.m
@@ -311,7 +311,12 @@ void setKeyboardsVZVirtualMachineConfiguration(void *config, void *keyboards)
  */
 void setAudioDevicesVZVirtualMachineConfiguration(void *config, void *audioDevices)
 {
-    [(VZVirtualMachineConfiguration *)config setAudioDevices:[(NSMutableArray *)audioDevices copy]];
+    if (@available(macOS 12, *)) {
+        [(VZVirtualMachineConfiguration *)config setAudioDevices:[(NSMutableArray *)audioDevices copy]];
+        return;
+    }
+
+    RAISE_UNSUPPORTED_MACOS_EXCEPTION();
 }
 
 /*!
@@ -320,7 +325,11 @@ void setAudioDevicesVZVirtualMachineConfiguration(void *config, void *audioDevic
  */
 void *newVZVirtioSoundDeviceConfiguration()
 {
-    return [[VZVirtioSoundDeviceConfiguration alloc] init];
+    if (@available(macOS 12, *)) {
+        return [[VZVirtioSoundDeviceConfiguration alloc] init];
+    }
+
+    RAISE_UNSUPPORTED_MACOS_EXCEPTION();
 }
 
 /*!
@@ -328,7 +337,12 @@ void *newVZVirtioSoundDeviceConfiguration()
 */
 void setStreamsVZVirtioSoundDeviceConfiguration(void *audioDeviceConfiguration, void *streams)
 {
-    [(VZVirtioSoundDeviceConfiguration *)audioDeviceConfiguration setStreams:[(NSMutableArray *)streams copy]];
+    if (@available(macOS 12, *)) {
+        [(VZVirtioSoundDeviceConfiguration *)audioDeviceConfiguration setStreams:[(NSMutableArray *)streams copy]];
+        return;
+    }
+
+    RAISE_UNSUPPORTED_MACOS_EXCEPTION();
 }
 
 /*!
@@ -337,7 +351,11 @@ void setStreamsVZVirtioSoundDeviceConfiguration(void *audioDeviceConfiguration, 
  */
 void *newVZVirtioSoundDeviceInputStreamConfiguration()
 {
-    return [[VZVirtioSoundDeviceInputStreamConfiguration alloc] init];
+    if (@available(macOS 12, *)) {
+        return [[VZVirtioSoundDeviceInputStreamConfiguration alloc] init];
+    }
+
+    RAISE_UNSUPPORTED_MACOS_EXCEPTION();
 }
 
 /*!
@@ -345,9 +363,13 @@ void *newVZVirtioSoundDeviceInputStreamConfiguration()
  */
 void *newVZVirtioSoundDeviceHostInputStreamConfiguration()
 {
-    VZVirtioSoundDeviceInputStreamConfiguration *inputStream = (VZVirtioSoundDeviceInputStreamConfiguration *)newVZVirtioSoundDeviceInputStreamConfiguration();
-    [inputStream setSource:[[VZHostAudioInputStreamSource alloc] init]];
-    return inputStream;
+    if (@available(macOS 12, *)) {
+        VZVirtioSoundDeviceInputStreamConfiguration *inputStream = (VZVirtioSoundDeviceInputStreamConfiguration *)newVZVirtioSoundDeviceInputStreamConfiguration();
+        [inputStream setSource:[[VZHostAudioInputStreamSource alloc] init]];
+        return inputStream;
+    }
+
+    RAISE_UNSUPPORTED_MACOS_EXCEPTION();
 }
 
 /*!
@@ -356,7 +378,11 @@ void *newVZVirtioSoundDeviceHostInputStreamConfiguration()
  */
 void *newVZVirtioSoundDeviceOutputStreamConfiguration()
 {
-    return [[VZVirtioSoundDeviceOutputStreamConfiguration alloc] init];
+    if (@available(macOS 12, *)) {
+        return [[VZVirtioSoundDeviceOutputStreamConfiguration alloc] init];
+    }
+
+    RAISE_UNSUPPORTED_MACOS_EXCEPTION();
 }
 
 /*!
@@ -364,9 +390,13 @@ void *newVZVirtioSoundDeviceOutputStreamConfiguration()
  */
 void *newVZVirtioSoundDeviceHostOutputStreamConfiguration()
 {
-    VZVirtioSoundDeviceOutputStreamConfiguration *outputStream = (VZVirtioSoundDeviceOutputStreamConfiguration *)newVZVirtioSoundDeviceOutputStreamConfiguration();
-    [outputStream setSink:[[VZHostAudioOutputStreamSink alloc] init]];
-    return outputStream;
+    if (@available(macOS 12, *)) {
+        VZVirtioSoundDeviceOutputStreamConfiguration *outputStream = (VZVirtioSoundDeviceOutputStreamConfiguration *)newVZVirtioSoundDeviceOutputStreamConfiguration();
+        [outputStream setSink:[[VZHostAudioOutputStreamSink alloc] init]];
+        return outputStream;
+    }
+
+    RAISE_UNSUPPORTED_MACOS_EXCEPTION();
 }
 
 /*!

--- a/virtualization.m
+++ b/virtualization.m
@@ -7,6 +7,12 @@
 #import "virtualization.h"
 #import "virtualization_view.h"
 
+#define RAISE_UNSUPPORTED_MACOS_EXCEPTION() \
+    do { \
+        [[NSException exceptionWithName:@"UnhandledException" reason:@"bug" userInfo:nil] raise]; \
+        __builtin_unreachable(); \
+    } while (0)
+
 char *copyCString(NSString *nss)
 {
     const char *cc = [nss UTF8String];
@@ -234,7 +240,12 @@ void setStorageDevicesVZVirtualMachineConfiguration(void *config,
  */
 void setDirectorySharingDevicesVZVirtualMachineConfiguration(void *config, void *directorySharingDevices)
 {
-    [(VZVirtualMachineConfiguration *)config setDirectorySharingDevices:[(NSMutableArray *)directorySharingDevices copy]];
+    if (@available(macOS 12, *)) {
+        [(VZVirtualMachineConfiguration *)config setDirectorySharingDevices:[(NSMutableArray *)directorySharingDevices copy]];
+        return;
+    }
+
+    RAISE_UNSUPPORTED_MACOS_EXCEPTION();
 }
 
 /*!
@@ -711,13 +722,17 @@ const char *getVZMACAddressString(void *macAddress)
  */
 void *newVZSharedDirectory(const char *dirPath, bool readOnly)
 {
-    VZSharedDirectory *ret;
-    @autoreleasepool {
-        NSString *dirPathNSString = [NSString stringWithUTF8String:dirPath];
-        NSURL *dirURL = [NSURL fileURLWithPath:dirPathNSString];
-        ret = [[VZSharedDirectory alloc] initWithURL:dirURL readOnly:(BOOL)readOnly];
+    if (@available(macOS 12, *)) {
+        VZSharedDirectory *ret;
+        @autoreleasepool {
+            NSString *dirPathNSString = [NSString stringWithUTF8String:dirPath];
+            NSURL *dirURL = [NSURL fileURLWithPath:dirPathNSString];
+            ret = [[VZSharedDirectory alloc] initWithURL:dirURL readOnly:(BOOL)readOnly];
+        }
+        return ret;
     }
-    return ret;
+
+    RAISE_UNSUPPORTED_MACOS_EXCEPTION();
 }
 
 /*!
@@ -728,7 +743,11 @@ void *newVZSharedDirectory(const char *dirPath, bool readOnly)
  */
 void *newVZSingleDirectoryShare(void *sharedDirectory)
 {
-    return [[VZSingleDirectoryShare alloc] initWithDirectory:(VZSharedDirectory *)sharedDirectory];
+    if (@available(macOS 12, *)) {
+        return [[VZSingleDirectoryShare alloc] initWithDirectory:(VZSharedDirectory *)sharedDirectory];
+    }
+
+    RAISE_UNSUPPORTED_MACOS_EXCEPTION();
 }
 
 /*!
@@ -739,7 +758,11 @@ void *newVZSingleDirectoryShare(void *sharedDirectory)
  */
 void *newVZMultipleDirectoryShare(void *sharedDirectories)
 {
-    return [[VZMultipleDirectoryShare alloc] initWithDirectories:(NSDictionary<NSString *, VZSharedDirectory *> *)sharedDirectories];
+    if (@available(macOS 12, *)) {
+        return [[VZMultipleDirectoryShare alloc] initWithDirectories:(NSDictionary<NSString *, VZSharedDirectory *> *)sharedDirectories];
+    }
+
+    RAISE_UNSUPPORTED_MACOS_EXCEPTION();
 }
 
 /*!
@@ -750,12 +773,16 @@ void *newVZMultipleDirectoryShare(void *sharedDirectories)
  */
 void *newVZVirtioFileSystemDeviceConfiguration(const char *tag)
 {
-    VZVirtioFileSystemDeviceConfiguration *ret;
-    @autoreleasepool {
-        NSString *tagNSString = [NSString stringWithUTF8String:tag];
-        ret = [[VZVirtioFileSystemDeviceConfiguration alloc] initWithTag:tagNSString];
+    if (@available(macOS 12, *)) {
+        VZVirtioFileSystemDeviceConfiguration *ret;
+        @autoreleasepool {
+            NSString *tagNSString = [NSString stringWithUTF8String:tag];
+            ret = [[VZVirtioFileSystemDeviceConfiguration alloc] initWithTag:tagNSString];
+        }
+        return ret;
     }
-    return ret;
+
+    RAISE_UNSUPPORTED_MACOS_EXCEPTION();
 }
 
 /*!
@@ -763,7 +790,12 @@ void *newVZVirtioFileSystemDeviceConfiguration(const char *tag)
  */
 void setVZVirtioFileSystemDeviceConfigurationShare(void *config, void *share)
 {
-    [(VZVirtioFileSystemDeviceConfiguration *)config setShare:(VZDirectoryShare *)share];
+    if (@available(macOS 12, *)) {
+        [(VZVirtioFileSystemDeviceConfiguration *)config setShare:(VZDirectoryShare *)share];
+        return;
+    }
+
+    RAISE_UNSUPPORTED_MACOS_EXCEPTION();
 }
 
 /*!

--- a/virtualization.m
+++ b/virtualization.m
@@ -255,7 +255,12 @@ void setDirectorySharingDevicesVZVirtualMachineConfiguration(void *config, void 
  */
 void setPlatformVZVirtualMachineConfiguration(void *config, void *platform)
 {
-    [(VZVirtualMachineConfiguration *)config setPlatform:(VZPlatformConfiguration *)platform];
+    if (@available(macOS 12, *)) {
+        [(VZVirtualMachineConfiguration *)config setPlatform:(VZPlatformConfiguration *)platform];
+        return;
+    }
+
+    RAISE_UNSUPPORTED_MACOS_EXCEPTION();
 }
 
 /*!
@@ -264,7 +269,12 @@ void setPlatformVZVirtualMachineConfiguration(void *config, void *platform)
  */
 void setGraphicsDevicesVZVirtualMachineConfiguration(void *config, void *graphicsDevices)
 {
-    [(VZVirtualMachineConfiguration *)config setGraphicsDevices:[(NSMutableArray *)graphicsDevices copy]];
+    if (@available(macOS 12, *)) {
+        [(VZVirtualMachineConfiguration *)config setGraphicsDevices:[(NSMutableArray *)graphicsDevices copy]];
+        return;
+    }
+
+    RAISE_UNSUPPORTED_MACOS_EXCEPTION();
 }
 
 /*!
@@ -354,7 +364,11 @@ void *newVZVirtioSoundDeviceHostOutputStreamConfiguration()
 */
 void *newVZGenericPlatformConfiguration()
 {
-    return [[VZGenericPlatformConfiguration alloc] init];
+    if (@available(macOS 12, *)) {
+        return [[VZGenericPlatformConfiguration alloc] init];
+    }
+
+    RAISE_UNSUPPORTED_MACOS_EXCEPTION();
 }
 
 /*!

--- a/virtualization.m
+++ b/virtualization.m
@@ -7,10 +7,10 @@
 #import "virtualization.h"
 #import "virtualization_view.h"
 
-#define RAISE_UNSUPPORTED_MACOS_EXCEPTION() \
-    do { \
+#define RAISE_UNSUPPORTED_MACOS_EXCEPTION()                                                       \
+    do {                                                                                          \
         [[NSException exceptionWithName:@"UnhandledException" reason:@"bug" userInfo:nil] raise]; \
-        __builtin_unreachable(); \
+        __builtin_unreachable();                                                                  \
     } while (0)
 
 char *copyCString(NSString *nss)

--- a/virtualization.m
+++ b/virtualization.m
@@ -283,7 +283,12 @@ void setGraphicsDevicesVZVirtualMachineConfiguration(void *config, void *graphic
  */
 void setPointingDevicesVZVirtualMachineConfiguration(void *config, void *pointingDevices)
 {
-    [(VZVirtualMachineConfiguration *)config setPointingDevices:[(NSMutableArray *)pointingDevices copy]];
+    if (@available(macOS 12, *)) {
+        [(VZVirtualMachineConfiguration *)config setPointingDevices:[(NSMutableArray *)pointingDevices copy]];
+        return;
+    }
+
+    RAISE_UNSUPPORTED_MACOS_EXCEPTION();
 }
 
 /*!
@@ -292,7 +297,12 @@ void setPointingDevicesVZVirtualMachineConfiguration(void *config, void *pointin
  */
 void setKeyboardsVZVirtualMachineConfiguration(void *config, void *keyboards)
 {
-    [(VZVirtualMachineConfiguration *)config setKeyboards:[(NSMutableArray *)keyboards copy]];
+    if (@available(macOS 12, *)) {
+        [(VZVirtualMachineConfiguration *)config setKeyboards:[(NSMutableArray *)keyboards copy]];
+        return;
+    }
+
+    RAISE_UNSUPPORTED_MACOS_EXCEPTION();
 }
 
 /*!
@@ -818,7 +828,11 @@ void setVZVirtioFileSystemDeviceConfigurationShare(void *config, void *share)
  */
 void *newVZUSBScreenCoordinatePointingDeviceConfiguration()
 {
-    return [[VZUSBScreenCoordinatePointingDeviceConfiguration alloc] init];
+    if (@available(macOS 12, *)) {
+        return [[VZUSBScreenCoordinatePointingDeviceConfiguration alloc] init];
+    }
+
+    RAISE_UNSUPPORTED_MACOS_EXCEPTION();
 }
 
 /*!
@@ -827,7 +841,11 @@ void *newVZUSBScreenCoordinatePointingDeviceConfiguration()
  */
 void *newVZUSBKeyboardConfiguration()
 {
-    return [[VZUSBKeyboardConfiguration alloc] init];
+    if (@available(macOS 12, *)) {
+        return [[VZUSBKeyboardConfiguration alloc] init];
+    }
+
+    RAISE_UNSUPPORTED_MACOS_EXCEPTION();
 }
 
 /*!

--- a/virtualization.m
+++ b/virtualization.m
@@ -929,11 +929,16 @@ void resumeWithCompletionHandler(void *machine, void *queue, void *completionHan
 
 void stopWithCompletionHandler(void *machine, void *queue, void *completionHandler)
 {
-    dispatch_sync((dispatch_queue_t)queue, ^{
-        [(VZVirtualMachine *)machine stopWithCompletionHandler:^(NSError *err) {
-            virtualMachineCompletionHandler(completionHandler, err);
-        }];
-    });
+    if (@available(macOS 12, *)) {
+        dispatch_sync((dispatch_queue_t)queue, ^{
+            [(VZVirtualMachine *)machine stopWithCompletionHandler:^(NSError *err) {
+                virtualMachineCompletionHandler(completionHandler, err);
+            }];
+        });
+        return;
+    }
+
+    RAISE_UNSUPPORTED_MACOS_EXCEPTION();
 }
 
 // TODO(codehex): use KVO
@@ -975,11 +980,15 @@ bool vmCanRequestStop(void *machine, void *queue)
 
 bool vmCanStop(void *machine, void *queue)
 {
-    __block BOOL result;
-    dispatch_sync((dispatch_queue_t)queue, ^{
-        result = ((VZVirtualMachine *)machine).canStop;
-    });
-    return (bool)result;
+    if (@available(macOS 12, *)) {
+        __block BOOL result;
+        dispatch_sync((dispatch_queue_t)queue, ^{
+            result = ((VZVirtualMachine *)machine).canStop;
+        });
+        return (bool)result;
+    }
+
+    RAISE_UNSUPPORTED_MACOS_EXCEPTION();
 }
 // --- TODO end
 

--- a/virtualization.m
+++ b/virtualization.m
@@ -42,13 +42,9 @@ char *copyCString(NSString *nss)
 @end
 
 @implementation VZVirtioSocketListenerDelegateImpl
-- (BOOL)listener:(void *)listener shouldAcceptNewConnection:(void *)connection fromSocketDevice:(void *)socketDevice;
+- (BOOL)listener:(VZVirtioSocketListener *)listener shouldAcceptNewConnection:(VZVirtioSocketConnection *)connection fromSocketDevice:(VZVirtioSocketDevice *)socketDevice;
 {
-    if (@available(macOS 11, *)) {
-        return (BOOL)shouldAcceptNewConnectionHandler((VZVirtioSocketListener *)listener, (VZVirtioSocketConnection *)connection, (VZVirtioSocketDevice *)socketDevice);
-    }
-
-    RAISE_UNSUPPORTED_MACOS_EXCEPTION();
+    return (BOOL)shouldAcceptNewConnectionHandler(listener, connection, socketDevice);
 }
 @end
 

--- a/virtualization_arm64.h
+++ b/virtualization_arm64.h
@@ -65,7 +65,7 @@ void *newVZMacMachineIdentifierWithPath(const char *machineIdentifierPath);
 void *newVZMacMachineIdentifierWithBytes(void *machineIdentifierBytes, int len);
 nbyteslice getVZMacMachineIdentifierDataRepresentation(void *machineIdentifierPtr);
 
-VZMacOSRestoreImageStruct convertVZMacOSRestoreImage2Struct(VZMacOSRestoreImage *restoreImage);
+VZMacOSRestoreImageStruct convertVZMacOSRestoreImage2Struct(void *restoreImagePtr);
 void fetchLatestSupportedMacOSRestoreImageWithCompletionHandler(void *cgoHandler);
 void loadMacOSRestoreImageFile(const char *ipswPath, void *cgoHandler);
 

--- a/virtualization_arm64.m
+++ b/virtualization_arm64.m
@@ -329,9 +329,10 @@ nbyteslice getVZMacMachineIdentifierDataRepresentation(void *machineIdentifierPt
     RAISE_UNSUPPORTED_MACOS_EXCEPTION();
 }
 
-VZMacOSRestoreImageStruct convertVZMacOSRestoreImage2Struct(VZMacOSRestoreImage *restoreImage)
+VZMacOSRestoreImageStruct convertVZMacOSRestoreImage2Struct(void *restoreImagePtr)
 {
     if (@available(macOS 12, *)) {
+        VZMacOSRestoreImage *restoreImage = (VZMacOSRestoreImage *)restoreImagePtr;
         VZMacOSRestoreImageStruct ret;
         ret.url = [[[restoreImage URL] absoluteString] UTF8String];
         ret.buildVersion = [[restoreImage buildVersion] UTF8String];

--- a/virtualization_arm64.m
+++ b/virtualization_arm64.m
@@ -1,10 +1,10 @@
 #ifdef __arm64__
 #import "virtualization_arm64.h"
 
-#define RAISE_UNSUPPORTED_MACOS_EXCEPTION() \
-    do { \
+#define RAISE_UNSUPPORTED_MACOS_EXCEPTION()                                                       \
+    do {                                                                                          \
         [[NSException exceptionWithName:@"UnhandledException" reason:@"bug" userInfo:nil] raise]; \
-        __builtin_unreachable(); \
+        __builtin_unreachable();                                                                  \
     } while (0)
 
 @implementation ProgressObserver


### PR DESCRIPTION
This PR adds version annotation to the objective C API so that it's possible to
build vz/use it on a macOS 10/11 machine even if it does not implement all the
latest virtualization.framework API. When trying to use unsupported API,
vz.ErrUnsupportedOSVersion will be returned.

This addresses https://github.com/Code-Hex/vz/issues/41 as this
allows to support macOS 10, macOS 11 and macOS 12 in the same build.
