### PR TITLE
Don't export objcutil.go API

### DIFF
--- a/audio.go
+++ b/audio.go
@@ -43,7 +43,7 @@ func NewVirtioSoundDeviceConfiguration() *VirtioSoundDeviceConfiguration {
 		},
 	}
 	runtime.SetFinalizer(config, func(self *VirtioSoundDeviceConfiguration) {
-		self.Release()
+		self.release()
 	})
 	return config
 }
@@ -87,7 +87,7 @@ func NewVirtioSoundDeviceHostInputStreamConfiguration() *VirtioSoundDeviceHostIn
 		},
 	}
 	runtime.SetFinalizer(config, func(self *VirtioSoundDeviceHostInputStreamConfiguration) {
-		self.Release()
+		self.release()
 	})
 	return config
 }
@@ -112,7 +112,7 @@ func NewVirtioSoundDeviceHostOutputStreamConfiguration() *VirtioSoundDeviceHostO
 		},
 	}
 	runtime.SetFinalizer(config, func(self *VirtioSoundDeviceHostOutputStreamConfiguration) {
-		self.Release()
+		self.release()
 	})
 	return config
 }

--- a/audio.go
+++ b/audio.go
@@ -38,9 +38,7 @@ var _ AudioDeviceConfiguration = (*VirtioSoundDeviceConfiguration)(nil)
 // NewVirtioSoundDeviceConfiguration creates a new sound device configuration.
 func NewVirtioSoundDeviceConfiguration() *VirtioSoundDeviceConfiguration {
 	config := &VirtioSoundDeviceConfiguration{
-		pointer: pointer{
-			ptr: C.newVZVirtioSoundDeviceConfiguration(),
-		},
+		pointer: newPointer(C.newVZVirtioSoundDeviceConfiguration()),
 	}
 	runtime.SetFinalizer(config, func(self *VirtioSoundDeviceConfiguration) {
 		self.release()
@@ -82,9 +80,7 @@ var _ VirtioSoundDeviceStreamConfiguration = (*VirtioSoundDeviceHostInputStreamC
 // NewVirtioSoundDeviceHostInputStreamConfiguration creates a new PCM stream configuration of input audio data from host.
 func NewVirtioSoundDeviceHostInputStreamConfiguration() *VirtioSoundDeviceHostInputStreamConfiguration {
 	config := &VirtioSoundDeviceHostInputStreamConfiguration{
-		pointer: pointer{
-			ptr: C.newVZVirtioSoundDeviceHostInputStreamConfiguration(),
-		},
+		pointer: newPointer(C.newVZVirtioSoundDeviceHostInputStreamConfiguration()),
 	}
 	runtime.SetFinalizer(config, func(self *VirtioSoundDeviceHostInputStreamConfiguration) {
 		self.release()
@@ -107,9 +103,7 @@ var _ VirtioSoundDeviceStreamConfiguration = (*VirtioSoundDeviceHostOutputStream
 // NewVirtioSoundDeviceHostOutputStreamConfiguration creates a new sounds device output stream configuration.
 func NewVirtioSoundDeviceHostOutputStreamConfiguration() *VirtioSoundDeviceHostOutputStreamConfiguration {
 	config := &VirtioSoundDeviceHostOutputStreamConfiguration{
-		pointer: pointer{
-			ptr: C.newVZVirtioSoundDeviceHostOutputStreamConfiguration(),
-		},
+		pointer: newPointer(C.newVZVirtioSoundDeviceHostOutputStreamConfiguration()),
 	}
 	runtime.SetFinalizer(config, func(self *VirtioSoundDeviceHostOutputStreamConfiguration) {
 		self.release()

--- a/audio.go
+++ b/audio.go
@@ -53,7 +53,7 @@ func (v *VirtioSoundDeviceConfiguration) SetStreams(streams ...VirtioSoundDevice
 		ptrs[i] = val
 	}
 	array := convertToNSMutableArray(ptrs)
-	C.setStreamsVZVirtioSoundDeviceConfiguration(v.Ptr(), array.Ptr())
+	C.setStreamsVZVirtioSoundDeviceConfiguration(v.ptr(), array.ptr())
 }
 
 // VirtioSoundDeviceStreamConfiguration interface for Virtio Sound Device Stream Configuration.

--- a/bootloader.go
+++ b/bootloader.go
@@ -53,7 +53,7 @@ func WithCommandLine(cmdLine string) LinuxBootLoaderOption {
 		b.cmdLine = cmdLine
 		cs := charWithGoString(cmdLine)
 		defer cs.Free()
-		C.setCommandLineVZLinuxBootLoader(b.Ptr(), cs.CString())
+		C.setCommandLineVZLinuxBootLoader(b.ptr(), cs.CString())
 	}
 }
 
@@ -63,7 +63,7 @@ func WithInitrd(initrdPath string) LinuxBootLoaderOption {
 		b.initrdPath = initrdPath
 		cs := charWithGoString(initrdPath)
 		defer cs.Free()
-		C.setInitialRamdiskURLVZLinuxBootLoader(b.Ptr(), cs.CString())
+		C.setInitialRamdiskURLVZLinuxBootLoader(b.ptr(), cs.CString())
 	}
 }
 

--- a/bootloader.go
+++ b/bootloader.go
@@ -73,11 +73,10 @@ func NewLinuxBootLoader(vmlinuz string, opts ...LinuxBootLoaderOption) *LinuxBoo
 	defer vmlinuzPath.Free()
 	bootLoader := &LinuxBootLoader{
 		vmlinuzPath: vmlinuz,
-		pointer: pointer{
-			ptr: C.newVZLinuxBootLoader(
-				vmlinuzPath.CString(),
-			),
-		},
+		pointer: newPointer(C.newVZLinuxBootLoader(
+			vmlinuzPath.CString(),
+		),
+		),
 	}
 	runtime.SetFinalizer(bootLoader, func(self *LinuxBootLoader) {
 		self.release()

--- a/bootloader.go
+++ b/bootloader.go
@@ -80,7 +80,7 @@ func NewLinuxBootLoader(vmlinuz string, opts ...LinuxBootLoaderOption) *LinuxBoo
 		},
 	}
 	runtime.SetFinalizer(bootLoader, func(self *LinuxBootLoader) {
-		self.Release()
+		self.release()
 	})
 	for _, opt := range opts {
 		opt(bootLoader)

--- a/bootloader_arm64.go
+++ b/bootloader_arm64.go
@@ -28,7 +28,7 @@ func NewMacOSBootLoader() *MacOSBootLoader {
 		},
 	}
 	runtime.SetFinalizer(bootLoader, func(self *MacOSBootLoader) {
-		self.Release()
+		self.release()
 	})
 	return bootLoader
 }

--- a/bootloader_arm64.go
+++ b/bootloader_arm64.go
@@ -23,9 +23,7 @@ var _ BootLoader = (*MacOSBootLoader)(nil)
 // NewMacOSBootLoader creates a new MacOSBootLoader struct.
 func NewMacOSBootLoader() *MacOSBootLoader {
 	bootLoader := &MacOSBootLoader{
-		pointer: pointer{
-			ptr: C.newVZMacOSBootLoader(),
-		},
+		pointer: newPointer(C.newVZMacOSBootLoader()),
 	}
 	runtime.SetFinalizer(bootLoader, func(self *MacOSBootLoader) {
 		self.release()

--- a/configuration.go
+++ b/configuration.go
@@ -48,7 +48,7 @@ func NewVirtualMachineConfiguration(bootLoader BootLoader, cpu uint, memorySize 
 		cpuCount:   cpu,
 		memorySize: memorySize,
 		pointer: newPointer(C.newVZVirtualMachineConfiguration(
-			bootLoader.Ptr(),
+			bootLoader.ptr(),
 			C.uint(cpu),
 			C.ulonglong(memorySize),
 		),
@@ -66,8 +66,8 @@ func NewVirtualMachineConfiguration(bootLoader BootLoader, cpu uint, memorySize 
 // If error is not nil, assigned with the validation error if the validation failed.
 func (v *VirtualMachineConfiguration) Validate() (bool, error) {
 	nserr := newNSErrorAsNil()
-	nserrPtr := nserr.Ptr()
-	ret := C.validateVZVirtualMachineConfiguration(v.Ptr(), &nserrPtr)
+	nserrPtr := nserr.ptr()
+	ret := C.validateVZVirtualMachineConfiguration(v.ptr(), &nserrPtr)
 	err := newNSError(nserrPtr)
 	if err != nil {
 		return false, err
@@ -82,7 +82,7 @@ func (v *VirtualMachineConfiguration) SetEntropyDevicesVirtualMachineConfigurati
 		ptrs[i] = val
 	}
 	array := convertToNSMutableArray(ptrs)
-	C.setEntropyDevicesVZVirtualMachineConfiguration(v.Ptr(), array.Ptr())
+	C.setEntropyDevicesVZVirtualMachineConfiguration(v.ptr(), array.ptr())
 }
 
 // SetMemoryBalloonDevicesVirtualMachineConfiguration sets list of memory balloon devices. Empty by default.
@@ -92,7 +92,7 @@ func (v *VirtualMachineConfiguration) SetMemoryBalloonDevicesVirtualMachineConfi
 		ptrs[i] = val
 	}
 	array := convertToNSMutableArray(ptrs)
-	C.setMemoryBalloonDevicesVZVirtualMachineConfiguration(v.Ptr(), array.Ptr())
+	C.setMemoryBalloonDevicesVZVirtualMachineConfiguration(v.ptr(), array.ptr())
 }
 
 // SetNetworkDevicesVirtualMachineConfiguration sets list of network adapters. Empty by default.
@@ -102,7 +102,7 @@ func (v *VirtualMachineConfiguration) SetNetworkDevicesVirtualMachineConfigurati
 		ptrs[i] = val
 	}
 	array := convertToNSMutableArray(ptrs)
-	C.setNetworkDevicesVZVirtualMachineConfiguration(v.Ptr(), array.Ptr())
+	C.setNetworkDevicesVZVirtualMachineConfiguration(v.ptr(), array.ptr())
 }
 
 // SetSerialPortsVirtualMachineConfiguration sets list of serial ports. Empty by default.
@@ -112,7 +112,7 @@ func (v *VirtualMachineConfiguration) SetSerialPortsVirtualMachineConfiguration(
 		ptrs[i] = val
 	}
 	array := convertToNSMutableArray(ptrs)
-	C.setSerialPortsVZVirtualMachineConfiguration(v.Ptr(), array.Ptr())
+	C.setSerialPortsVZVirtualMachineConfiguration(v.ptr(), array.ptr())
 }
 
 // SetSocketDevicesVirtualMachineConfiguration sets list of socket devices. Empty by default.
@@ -122,7 +122,7 @@ func (v *VirtualMachineConfiguration) SetSocketDevicesVirtualMachineConfiguratio
 		ptrs[i] = val
 	}
 	array := convertToNSMutableArray(ptrs)
-	C.setSocketDevicesVZVirtualMachineConfiguration(v.Ptr(), array.Ptr())
+	C.setSocketDevicesVZVirtualMachineConfiguration(v.ptr(), array.ptr())
 }
 
 // SetStorageDevicesVirtualMachineConfiguration sets list of disk devices. Empty by default.
@@ -132,7 +132,7 @@ func (v *VirtualMachineConfiguration) SetStorageDevicesVirtualMachineConfigurati
 		ptrs[i] = val
 	}
 	array := convertToNSMutableArray(ptrs)
-	C.setStorageDevicesVZVirtualMachineConfiguration(v.Ptr(), array.Ptr())
+	C.setStorageDevicesVZVirtualMachineConfiguration(v.ptr(), array.ptr())
 }
 
 // SetDirectorySharingDevicesVirtualMachineConfiguration sets list of directory sharing devices. Empty by default.
@@ -142,12 +142,12 @@ func (v *VirtualMachineConfiguration) SetDirectorySharingDevicesVirtualMachineCo
 		ptrs[i] = val
 	}
 	array := convertToNSMutableArray(ptrs)
-	C.setDirectorySharingDevicesVZVirtualMachineConfiguration(v.Ptr(), array.Ptr())
+	C.setDirectorySharingDevicesVZVirtualMachineConfiguration(v.ptr(), array.ptr())
 }
 
 // SetPlatformVirtualMachineConfiguration sets the hardware platform to use. Defaults to GenericPlatformConfiguration.
 func (v *VirtualMachineConfiguration) SetPlatformVirtualMachineConfiguration(c PlatformConfiguration) {
-	C.setPlatformVZVirtualMachineConfiguration(v.Ptr(), c.Ptr())
+	C.setPlatformVZVirtualMachineConfiguration(v.ptr(), c.ptr())
 }
 
 // SetGraphicsDevicesVirtualMachineConfiguration sets list of graphics devices. Empty by default.
@@ -157,7 +157,7 @@ func (v *VirtualMachineConfiguration) SetGraphicsDevicesVirtualMachineConfigurat
 		ptrs[i] = val
 	}
 	array := convertToNSMutableArray(ptrs)
-	C.setGraphicsDevicesVZVirtualMachineConfiguration(v.Ptr(), array.Ptr())
+	C.setGraphicsDevicesVZVirtualMachineConfiguration(v.ptr(), array.ptr())
 }
 
 // SetPointingDevicesVirtualMachineConfiguration sets list of pointing devices. Empty by default.
@@ -167,7 +167,7 @@ func (v *VirtualMachineConfiguration) SetPointingDevicesVirtualMachineConfigurat
 		ptrs[i] = val
 	}
 	array := convertToNSMutableArray(ptrs)
-	C.setPointingDevicesVZVirtualMachineConfiguration(v.Ptr(), array.Ptr())
+	C.setPointingDevicesVZVirtualMachineConfiguration(v.ptr(), array.ptr())
 }
 
 // SetKeyboardsVirtualMachineConfiguration sets list of keyboards. Empty by default.
@@ -177,7 +177,7 @@ func (v *VirtualMachineConfiguration) SetKeyboardsVirtualMachineConfiguration(cs
 		ptrs[i] = val
 	}
 	array := convertToNSMutableArray(ptrs)
-	C.setKeyboardsVZVirtualMachineConfiguration(v.Ptr(), array.Ptr())
+	C.setKeyboardsVZVirtualMachineConfiguration(v.ptr(), array.ptr())
 }
 
 // SetAudioDevicesVirtualMachineConfiguration sets list of audio devices. Empty by default.
@@ -187,7 +187,7 @@ func (v *VirtualMachineConfiguration) SetAudioDevicesVirtualMachineConfiguration
 		ptrs[i] = val
 	}
 	array := convertToNSMutableArray(ptrs)
-	C.setAudioDevicesVZVirtualMachineConfiguration(v.Ptr(), array.Ptr())
+	C.setAudioDevicesVZVirtualMachineConfiguration(v.ptr(), array.ptr())
 }
 
 // VirtualMachineConfigurationMinimumAllowedMemorySize returns minimum

--- a/configuration.go
+++ b/configuration.go
@@ -56,7 +56,7 @@ func NewVirtualMachineConfiguration(bootLoader BootLoader, cpu uint, memorySize 
 		},
 	}
 	runtime.SetFinalizer(config, func(self *VirtualMachineConfiguration) {
-		self.Release()
+		self.release()
 	})
 	return config
 }

--- a/configuration.go
+++ b/configuration.go
@@ -47,13 +47,12 @@ func NewVirtualMachineConfiguration(bootLoader BootLoader, cpu uint, memorySize 
 	config := &VirtualMachineConfiguration{
 		cpuCount:   cpu,
 		memorySize: memorySize,
-		pointer: pointer{
-			ptr: C.newVZVirtualMachineConfiguration(
-				bootLoader.Ptr(),
-				C.uint(cpu),
-				C.ulonglong(memorySize),
-			),
-		},
+		pointer: newPointer(C.newVZVirtualMachineConfiguration(
+			bootLoader.Ptr(),
+			C.uint(cpu),
+			C.ulonglong(memorySize),
+		),
+		),
 	}
 	runtime.SetFinalizer(config, func(self *VirtualMachineConfiguration) {
 		self.release()

--- a/console.go
+++ b/console.go
@@ -42,12 +42,11 @@ type FileHandleSerialPortAttachment struct {
 // write parameter is an *os.File for writing to the file.
 func NewFileHandleSerialPortAttachment(read, write *os.File) *FileHandleSerialPortAttachment {
 	attachment := &FileHandleSerialPortAttachment{
-		pointer: pointer{
-			ptr: C.newVZFileHandleSerialPortAttachment(
-				C.int(read.Fd()),
-				C.int(write.Fd()),
-			),
-		},
+		pointer: newPointer(C.newVZFileHandleSerialPortAttachment(
+			C.int(read.Fd()),
+			C.int(write.Fd()),
+		),
+		),
 	}
 	runtime.SetFinalizer(attachment, func(self *FileHandleSerialPortAttachment) {
 		self.release()
@@ -81,13 +80,12 @@ func NewFileSerialPortAttachment(path string, shouldAppend bool) (*FileSerialPor
 	nserr := newNSErrorAsNil()
 	nserrPtr := nserr.Ptr()
 	attachment := &FileSerialPortAttachment{
-		pointer: pointer{
-			ptr: C.newVZFileSerialPortAttachment(
-				cpath.CString(),
-				C.bool(shouldAppend),
-				&nserrPtr,
-			),
-		},
+		pointer: newPointer(C.newVZFileSerialPortAttachment(
+			cpath.CString(),
+			C.bool(shouldAppend),
+			&nserrPtr,
+		),
+		),
 	}
 	if err := newNSError(nserrPtr); err != nil {
 		return nil, err
@@ -110,11 +108,10 @@ type VirtioConsoleDeviceSerialPortConfiguration struct {
 // NewVirtioConsoleDeviceSerialPortConfiguration creates a new NewVirtioConsoleDeviceSerialPortConfiguration.
 func NewVirtioConsoleDeviceSerialPortConfiguration(attachment SerialPortAttachment) *VirtioConsoleDeviceSerialPortConfiguration {
 	config := &VirtioConsoleDeviceSerialPortConfiguration{
-		pointer: pointer{
-			ptr: C.newVZVirtioConsoleDeviceSerialPortConfiguration(
-				attachment.Ptr(),
-			),
-		},
+		pointer: newPointer(C.newVZVirtioConsoleDeviceSerialPortConfiguration(
+			attachment.Ptr(),
+		),
+		),
 	}
 	runtime.SetFinalizer(config, func(self *VirtioConsoleDeviceSerialPortConfiguration) {
 		self.release()

--- a/console.go
+++ b/console.go
@@ -50,7 +50,7 @@ func NewFileHandleSerialPortAttachment(read, write *os.File) *FileHandleSerialPo
 		},
 	}
 	runtime.SetFinalizer(attachment, func(self *FileHandleSerialPortAttachment) {
-		self.Release()
+		self.release()
 	})
 	return attachment
 }
@@ -93,7 +93,7 @@ func NewFileSerialPortAttachment(path string, shouldAppend bool) (*FileSerialPor
 		return nil, err
 	}
 	runtime.SetFinalizer(attachment, func(self *FileSerialPortAttachment) {
-		self.Release()
+		self.release()
 	})
 	return attachment, nil
 }
@@ -117,7 +117,7 @@ func NewVirtioConsoleDeviceSerialPortConfiguration(attachment SerialPortAttachme
 		},
 	}
 	runtime.SetFinalizer(config, func(self *VirtioConsoleDeviceSerialPortConfiguration) {
-		self.Release()
+		self.release()
 	})
 	return config
 }

--- a/console.go
+++ b/console.go
@@ -78,7 +78,7 @@ func NewFileSerialPortAttachment(path string, shouldAppend bool) (*FileSerialPor
 	defer cpath.Free()
 
 	nserr := newNSErrorAsNil()
-	nserrPtr := nserr.Ptr()
+	nserrPtr := nserr.ptr()
 	attachment := &FileSerialPortAttachment{
 		pointer: newPointer(C.newVZFileSerialPortAttachment(
 			cpath.CString(),
@@ -109,7 +109,7 @@ type VirtioConsoleDeviceSerialPortConfiguration struct {
 func NewVirtioConsoleDeviceSerialPortConfiguration(attachment SerialPortAttachment) *VirtioConsoleDeviceSerialPortConfiguration {
 	config := &VirtioConsoleDeviceSerialPortConfiguration{
 		pointer: newPointer(C.newVZVirtioConsoleDeviceSerialPortConfiguration(
-			attachment.Ptr(),
+			attachment.ptr(),
 		),
 		),
 	}

--- a/entropy.go
+++ b/entropy.go
@@ -20,9 +20,7 @@ type VirtioEntropyDeviceConfiguration struct {
 // NewVirtioEntropyDeviceConfiguration creates a new Virtio Entropy Device confiuration.
 func NewVirtioEntropyDeviceConfiguration() *VirtioEntropyDeviceConfiguration {
 	config := &VirtioEntropyDeviceConfiguration{
-		pointer: pointer{
-			ptr: C.newVZVirtioEntropyDeviceConfiguration(),
-		},
+		pointer: newPointer(C.newVZVirtioEntropyDeviceConfiguration()),
 	}
 	runtime.SetFinalizer(config, func(self *VirtioEntropyDeviceConfiguration) {
 		self.release()

--- a/entropy.go
+++ b/entropy.go
@@ -25,7 +25,7 @@ func NewVirtioEntropyDeviceConfiguration() *VirtioEntropyDeviceConfiguration {
 		},
 	}
 	runtime.SetFinalizer(config, func(self *VirtioEntropyDeviceConfiguration) {
-		self.Release()
+		self.release()
 	})
 	return config
 }

--- a/graphics_arm64.go
+++ b/graphics_arm64.go
@@ -38,7 +38,7 @@ func (m *MacGraphicsDeviceConfiguration) SetDisplays(displayConfigs ...*MacGraph
 		ptrs[i] = val
 	}
 	array := convertToNSMutableArray(ptrs)
-	C.setDisplaysVZMacGraphicsDeviceConfiguration(m.Ptr(), array.Ptr())
+	C.setDisplaysVZMacGraphicsDeviceConfiguration(m.ptr(), array.ptr())
 }
 
 // MacGraphicsDisplayConfiguration is the configuration for a Mac graphics device.

--- a/graphics_arm64.go
+++ b/graphics_arm64.go
@@ -28,7 +28,7 @@ func NewMacGraphicsDeviceConfiguration() *MacGraphicsDeviceConfiguration {
 		},
 	}
 	runtime.SetFinalizer(graphicsConfiguration, func(self *MacGraphicsDeviceConfiguration) {
-		self.Release()
+		self.release()
 	})
 	return graphicsConfiguration
 }
@@ -62,7 +62,7 @@ func NewMacGraphicsDisplayConfiguration(widthInPixels int64, heightInPixels int6
 		},
 	}
 	runtime.SetFinalizer(graphicsDisplayConfiguration, func(self *MacGraphicsDisplayConfiguration) {
-		self.Release()
+		self.release()
 	})
 	return graphicsDisplayConfiguration
 }

--- a/graphics_arm64.go
+++ b/graphics_arm64.go
@@ -23,9 +23,7 @@ var _ GraphicsDeviceConfiguration = (*MacGraphicsDeviceConfiguration)(nil)
 // NewMacGraphicsDeviceConfiguration creates a new MacGraphicsDeviceConfiguration.
 func NewMacGraphicsDeviceConfiguration() *MacGraphicsDeviceConfiguration {
 	graphicsConfiguration := &MacGraphicsDeviceConfiguration{
-		pointer: pointer{
-			ptr: C.newVZMacGraphicsDeviceConfiguration(),
-		},
+		pointer: newPointer(C.newVZMacGraphicsDeviceConfiguration()),
 	}
 	runtime.SetFinalizer(graphicsConfiguration, func(self *MacGraphicsDeviceConfiguration) {
 		self.release()
@@ -53,13 +51,12 @@ type MacGraphicsDisplayConfiguration struct {
 // Creates a display configuration with the specified pixel dimensions and pixel density.
 func NewMacGraphicsDisplayConfiguration(widthInPixels int64, heightInPixels int64, pixelsPerInch int64) *MacGraphicsDisplayConfiguration {
 	graphicsDisplayConfiguration := &MacGraphicsDisplayConfiguration{
-		pointer: pointer{
-			ptr: C.newVZMacGraphicsDisplayConfiguration(
-				C.NSInteger(widthInPixels),
-				C.NSInteger(heightInPixels),
-				C.NSInteger(pixelsPerInch),
-			),
-		},
+		pointer: newPointer(C.newVZMacGraphicsDisplayConfiguration(
+			C.NSInteger(widthInPixels),
+			C.NSInteger(heightInPixels),
+			C.NSInteger(pixelsPerInch),
+		),
+		),
 	}
 	runtime.SetFinalizer(graphicsDisplayConfiguration, func(self *MacGraphicsDisplayConfiguration) {
 		self.release()

--- a/keyboard.go
+++ b/keyboard.go
@@ -31,9 +31,7 @@ var _ KeyboardConfiguration = (*USBKeyboardConfiguration)(nil)
 // NewUSBKeyboardConfiguration creates a new USB keyboard configuration.
 func NewUSBKeyboardConfiguration() *USBKeyboardConfiguration {
 	config := &USBKeyboardConfiguration{
-		pointer: pointer{
-			ptr: C.newVZUSBKeyboardConfiguration(),
-		},
+		pointer: newPointer(C.newVZUSBKeyboardConfiguration()),
 	}
 	runtime.SetFinalizer(config, func(self *USBKeyboardConfiguration) {
 		self.release()

--- a/keyboard.go
+++ b/keyboard.go
@@ -36,7 +36,7 @@ func NewUSBKeyboardConfiguration() *USBKeyboardConfiguration {
 		},
 	}
 	runtime.SetFinalizer(config, func(self *USBKeyboardConfiguration) {
-		self.Release()
+		self.release()
 	})
 	return config
 }

--- a/memory_balloon.go
+++ b/memory_balloon.go
@@ -38,7 +38,7 @@ func NewVirtioTraditionalMemoryBalloonDeviceConfiguration() *VirtioTraditionalMe
 		},
 	}
 	runtime.SetFinalizer(config, func(self *VirtioTraditionalMemoryBalloonDeviceConfiguration) {
-		self.Release()
+		self.release()
 	})
 	return config
 }

--- a/memory_balloon.go
+++ b/memory_balloon.go
@@ -33,9 +33,7 @@ type VirtioTraditionalMemoryBalloonDeviceConfiguration struct {
 // NewVirtioTraditionalMemoryBalloonDeviceConfiguration creates a new VirtioTraditionalMemoryBalloonDeviceConfiguration.
 func NewVirtioTraditionalMemoryBalloonDeviceConfiguration() *VirtioTraditionalMemoryBalloonDeviceConfiguration {
 	config := &VirtioTraditionalMemoryBalloonDeviceConfiguration{
-		pointer: pointer{
-			ptr: C.newVZVirtioTraditionalMemoryBalloonDeviceConfiguration(),
-		},
+		pointer: newPointer(C.newVZVirtioTraditionalMemoryBalloonDeviceConfiguration()),
 	}
 	runtime.SetFinalizer(config, func(self *VirtioTraditionalMemoryBalloonDeviceConfiguration) {
 		self.release()

--- a/network.go
+++ b/network.go
@@ -55,7 +55,7 @@ func NewNATNetworkDeviceAttachment() *NATNetworkDeviceAttachment {
 		},
 	}
 	runtime.SetFinalizer(attachment, func(self *NATNetworkDeviceAttachment) {
-		self.Release()
+		self.release()
 	})
 	return attachment
 }
@@ -88,7 +88,7 @@ func NewBridgedNetworkDeviceAttachment(networkInterface BridgedNetwork) *Bridged
 		},
 	}
 	runtime.SetFinalizer(attachment, func(self *BridgedNetworkDeviceAttachment) {
-		self.Release()
+		self.release()
 	})
 	return attachment
 }
@@ -118,7 +118,7 @@ func NewFileHandleNetworkDeviceAttachment(file *os.File) *FileHandleNetworkDevic
 		},
 	}
 	runtime.SetFinalizer(attachment, func(self *FileHandleNetworkDeviceAttachment) {
-		self.Release()
+		self.release()
 	})
 	return attachment
 }
@@ -157,7 +157,7 @@ func NewVirtioNetworkDeviceConfiguration(attachment NetworkDeviceAttachment) *Vi
 		},
 	}
 	runtime.SetFinalizer(config, func(self *VirtioNetworkDeviceConfiguration) {
-		self.Release()
+		self.release()
 	})
 	return config
 }
@@ -182,7 +182,7 @@ func NewMACAddress(macAddr net.HardwareAddr) *MACAddress {
 		},
 	}
 	runtime.SetFinalizer(ma, func(self *MACAddress) {
-		self.Release()
+		self.release()
 	})
 	return ma
 }
@@ -195,7 +195,7 @@ func NewRandomLocallyAdministeredMACAddress() *MACAddress {
 		},
 	}
 	runtime.SetFinalizer(ma, func(self *MACAddress) {
-		self.Release()
+		self.release()
 	})
 	return ma
 }

--- a/network.go
+++ b/network.go
@@ -50,9 +50,7 @@ var _ NetworkDeviceAttachment = (*NATNetworkDeviceAttachment)(nil)
 // NewNATNetworkDeviceAttachment creates a new NATNetworkDeviceAttachment.
 func NewNATNetworkDeviceAttachment() *NATNetworkDeviceAttachment {
 	attachment := &NATNetworkDeviceAttachment{
-		pointer: pointer{
-			ptr: C.newVZNATNetworkDeviceAttachment(),
-		},
+		pointer: newPointer(C.newVZNATNetworkDeviceAttachment()),
 	}
 	runtime.SetFinalizer(attachment, func(self *NATNetworkDeviceAttachment) {
 		self.release()
@@ -81,11 +79,10 @@ var _ NetworkDeviceAttachment = (*BridgedNetworkDeviceAttachment)(nil)
 // NewBridgedNetworkDeviceAttachment creates a new BridgedNetworkDeviceAttachment with networkInterface.
 func NewBridgedNetworkDeviceAttachment(networkInterface BridgedNetwork) *BridgedNetworkDeviceAttachment {
 	attachment := &BridgedNetworkDeviceAttachment{
-		pointer: pointer{
-			ptr: C.newVZBridgedNetworkDeviceAttachment(
-				networkInterface.Ptr(),
-			),
-		},
+		pointer: newPointer(C.newVZBridgedNetworkDeviceAttachment(
+			networkInterface.Ptr(),
+		),
+		),
 	}
 	runtime.SetFinalizer(attachment, func(self *BridgedNetworkDeviceAttachment) {
 		self.release()
@@ -111,11 +108,10 @@ var _ NetworkDeviceAttachment = (*FileHandleNetworkDeviceAttachment)(nil)
 // file parameter is holding a connected datagram socket.
 func NewFileHandleNetworkDeviceAttachment(file *os.File) *FileHandleNetworkDeviceAttachment {
 	attachment := &FileHandleNetworkDeviceAttachment{
-		pointer: pointer{
-			ptr: C.newVZFileHandleNetworkDeviceAttachment(
-				C.int(file.Fd()),
-			),
-		},
+		pointer: newPointer(C.newVZFileHandleNetworkDeviceAttachment(
+			C.int(file.Fd()),
+		),
+		),
 	}
 	runtime.SetFinalizer(attachment, func(self *FileHandleNetworkDeviceAttachment) {
 		self.release()
@@ -150,11 +146,10 @@ type VirtioNetworkDeviceConfiguration struct {
 // NewVirtioNetworkDeviceConfiguration creates a new VirtioNetworkDeviceConfiguration with NetworkDeviceAttachment.
 func NewVirtioNetworkDeviceConfiguration(attachment NetworkDeviceAttachment) *VirtioNetworkDeviceConfiguration {
 	config := &VirtioNetworkDeviceConfiguration{
-		pointer: pointer{
-			ptr: C.newVZVirtioNetworkDeviceConfiguration(
-				attachment.Ptr(),
-			),
-		},
+		pointer: newPointer(C.newVZVirtioNetworkDeviceConfiguration(
+			attachment.Ptr(),
+		),
+		),
 	}
 	runtime.SetFinalizer(config, func(self *VirtioNetworkDeviceConfiguration) {
 		self.release()
@@ -177,9 +172,7 @@ func NewMACAddress(macAddr net.HardwareAddr) *MACAddress {
 	macAddrChar := charWithGoString(macAddr.String())
 	defer macAddrChar.Free()
 	ma := &MACAddress{
-		pointer: pointer{
-			ptr: C.newVZMACAddress(macAddrChar.CString()),
-		},
+		pointer: newPointer(C.newVZMACAddress(macAddrChar.CString())),
 	}
 	runtime.SetFinalizer(ma, func(self *MACAddress) {
 		self.release()
@@ -190,9 +183,7 @@ func NewMACAddress(macAddr net.HardwareAddr) *MACAddress {
 // NewRandomLocallyAdministeredMACAddress creates a valid, random, unicast, locally administered address.
 func NewRandomLocallyAdministeredMACAddress() *MACAddress {
 	ma := &MACAddress{
-		pointer: pointer{
-			ptr: C.newRandomLocallyAdministeredVZMACAddress(),
-		},
+		pointer: newPointer(C.newRandomLocallyAdministeredVZMACAddress()),
 	}
 	runtime.SetFinalizer(ma, func(self *MACAddress) {
 		self.release()

--- a/network.go
+++ b/network.go
@@ -80,7 +80,7 @@ var _ NetworkDeviceAttachment = (*BridgedNetworkDeviceAttachment)(nil)
 func NewBridgedNetworkDeviceAttachment(networkInterface BridgedNetwork) *BridgedNetworkDeviceAttachment {
 	attachment := &BridgedNetworkDeviceAttachment{
 		pointer: newPointer(C.newVZBridgedNetworkDeviceAttachment(
-			networkInterface.Ptr(),
+			networkInterface.ptr(),
 		),
 		),
 	}
@@ -147,7 +147,7 @@ type VirtioNetworkDeviceConfiguration struct {
 func NewVirtioNetworkDeviceConfiguration(attachment NetworkDeviceAttachment) *VirtioNetworkDeviceConfiguration {
 	config := &VirtioNetworkDeviceConfiguration{
 		pointer: newPointer(C.newVZVirtioNetworkDeviceConfiguration(
-			attachment.Ptr(),
+			attachment.ptr(),
 		),
 		),
 	}
@@ -158,7 +158,7 @@ func NewVirtioNetworkDeviceConfiguration(attachment NetworkDeviceAttachment) *Vi
 }
 
 func (v *VirtioNetworkDeviceConfiguration) SetMACAddress(macAddress *MACAddress) {
-	C.setNetworkDevicesVZMACAddress(v.Ptr(), macAddress.Ptr())
+	C.setNetworkDevicesVZMACAddress(v.ptr(), macAddress.ptr())
 }
 
 // MACAddress represents a media access control address (MAC address), the 48-bit ethernet address.
@@ -192,7 +192,7 @@ func NewRandomLocallyAdministeredMACAddress() *MACAddress {
 }
 
 func (m *MACAddress) String() string {
-	cstring := (*char)(C.getVZMACAddressString(m.Ptr()))
+	cstring := (*char)(C.getVZMACAddressString(m.ptr()))
 	return cstring.String()
 }
 

--- a/objcutil.go
+++ b/objcutil.go
@@ -158,6 +158,12 @@ type pointer struct {
 	ptr unsafe.Pointer
 }
 
+func newPointer(ptr unsafe.Pointer) pointer {
+	return pointer{
+		ptr: ptr,
+	}
+}
+
 // release releases allocated resources in objective-c world.
 func (p *pointer) release() {
 	C.releaseNSObject(p.Ptr())
@@ -204,10 +210,8 @@ type nsError struct {
 
 // newNSErrorAsNil makes nil NSError in objective-c world.
 func newNSErrorAsNil() *pointer {
-	p := &pointer{
-		ptr: unsafe.Pointer(C.newNSError()),
-	}
-	return p
+	p := newPointer(unsafe.Pointer(C.newNSError()))
+	return &p
 }
 
 // hasNSError checks passed pointer is NSError or not.
@@ -248,11 +252,11 @@ func convertToNSMutableArray(s []NSObject) *pointer {
 	for _, v := range s {
 		C.addNSMutableArrayVal(ary, v.Ptr())
 	}
-	p := &pointer{ptr: ary}
+	p := newPointer(ary)
 	runtime.SetFinalizer(p, func(self *pointer) {
 		self.release()
 	})
-	return p
+	return &p
 }
 
 func convertToNSMutableDictionary(d map[string]NSObject) *pointer {
@@ -262,11 +266,11 @@ func convertToNSMutableDictionary(d map[string]NSObject) *pointer {
 		C.insertNSMutableDictionary(dict, cs.CString(), value.Ptr())
 		cs.Free()
 	}
-	p := &pointer{ptr: dict}
+	p := newPointer(dict)
 	runtime.SetFinalizer(p, func(self *pointer) {
 		self.release()
 	})
-	return p
+	return &p
 }
 
 func getUUID() *char {

--- a/objcutil.go
+++ b/objcutil.go
@@ -193,8 +193,8 @@ func (n *nsArray) ToPointerSlice() []unsafe.Pointer {
 	return ret
 }
 
-// NSError indicates NSError.
-type NSError struct {
+// nsError indicates objc NSError.
+type nsError struct {
 	Domain               string
 	Code                 int
 	LocalizedDescription string
@@ -215,7 +215,7 @@ func hasNSError(nserrPtr unsafe.Pointer) bool {
 	return (bool)(C.hasError(nserrPtr))
 }
 
-func (n *NSError) Error() string {
+func (n *nsError) Error() string {
 	if n == nil {
 		return "<nil>"
 	}
@@ -228,16 +228,16 @@ func (n *NSError) Error() string {
 	)
 }
 
-func newNSError(p unsafe.Pointer) *NSError {
+func newNSError(p unsafe.Pointer) *nsError {
 	if !hasNSError(p) {
 		return nil
 	}
-	nsError := C.convertNSError2Flat(p)
-	return &NSError{
-		Domain:               (*char)(nsError.domain).String(),
-		Code:                 int((nsError.code)),
-		LocalizedDescription: (*char)(nsError.localizedDescription).String(),
-		UserInfo:             (*char)(nsError.userinfo).String(), // NOTE(codehex): maybe we can convert to map[string]interface{}
+	nserror := C.convertNSError2Flat(p)
+	return &nsError{
+		Domain:               (*char)(nserror.domain).String(),
+		Code:                 int((nserror.code)),
+		LocalizedDescription: (*char)(nserror.localizedDescription).String(),
+		UserInfo:             (*char)(nserror.userinfo).String(), // NOTE(codehex): maybe we can convert to map[string]interface{}
 	}
 }
 

--- a/objcutil.go
+++ b/objcutil.go
@@ -177,13 +177,13 @@ type NSObject interface {
 	Ptr() unsafe.Pointer
 }
 
-// NSArray indicates NSArray
-type NSArray struct {
+// nsArray indicates objc NSArray
+type nsArray struct {
 	pointer
 }
 
 // ToPointerSlice method returns slice of the obj-c object as unsafe.Pointer.
-func (n *NSArray) ToPointerSlice() []unsafe.Pointer {
+func (n *nsArray) ToPointerSlice() []unsafe.Pointer {
 	count := int(C.getNSArrayCount(n.Ptr()))
 	ret := make([]unsafe.Pointer, count)
 	for i := 0; i < count; i++ {

--- a/objcutil.go
+++ b/objcutil.go
@@ -173,6 +173,7 @@ func (o *pointer) Ptr() unsafe.Pointer {
 }
 
 // NSObject indicates NSObject
+// nsObject, ptr(), no need to export?
 type NSObject interface {
 	Ptr() unsafe.Pointer
 }

--- a/objcutil.go
+++ b/objcutil.go
@@ -158,8 +158,8 @@ type pointer struct {
 	ptr unsafe.Pointer
 }
 
-// Release releases allocated resources in objective-c world.
-func (p *pointer) Release() {
+// release releases allocated resources in objective-c world.
+func (p *pointer) release() {
 	C.releaseNSObject(p.Ptr())
 	runtime.KeepAlive(p)
 }
@@ -250,7 +250,7 @@ func convertToNSMutableArray(s []NSObject) *pointer {
 	}
 	p := &pointer{ptr: ary}
 	runtime.SetFinalizer(p, func(self *pointer) {
-		self.Release()
+		self.release()
 	})
 	return p
 }
@@ -264,7 +264,7 @@ func convertToNSMutableDictionary(d map[string]NSObject) *pointer {
 	}
 	p := &pointer{ptr: dict}
 	runtime.SetFinalizer(p, func(self *pointer) {
-		self.Release()
+		self.release()
 	})
 	return p
 }

--- a/platform.go
+++ b/platform.go
@@ -36,7 +36,7 @@ func NewGenericPlatformConfiguration() *GenericPlatformConfiguration {
 		},
 	}
 	runtime.SetFinalizer(platformConfig, func(self *GenericPlatformConfiguration) {
-		self.Release()
+		self.release()
 	})
 	return platformConfig
 }

--- a/platform.go
+++ b/platform.go
@@ -31,9 +31,7 @@ var _ PlatformConfiguration = (*GenericPlatformConfiguration)(nil)
 // NewGenericPlatformConfiguration creates a new generic platform configuration.
 func NewGenericPlatformConfiguration() *GenericPlatformConfiguration {
 	platformConfig := &GenericPlatformConfiguration{
-		pointer: pointer{
-			ptr: C.newVZGenericPlatformConfiguration(),
-		},
+		pointer: newPointer(C.newVZGenericPlatformConfiguration()),
 	}
 	runtime.SetFinalizer(platformConfig, func(self *GenericPlatformConfiguration) {
 		self.release()

--- a/platform_arm64.go
+++ b/platform_arm64.go
@@ -69,9 +69,7 @@ func WithAuxiliaryStorage(m *MacAuxiliaryStorage) MacPlatformConfigurationOption
 // NewMacPlatformConfiguration creates a new MacPlatformConfiguration. see also it's document.
 func NewMacPlatformConfiguration(opts ...MacPlatformConfigurationOption) *MacPlatformConfiguration {
 	platformConfig := &MacPlatformConfiguration{
-		pointer: pointer{
-			ptr: C.newVZMacPlatformConfiguration(),
-		},
+		pointer: newPointer(C.newVZMacPlatformConfiguration()),
 	}
 	for _, optFunc := range opts {
 		optFunc(platformConfig)

--- a/platform_arm64.go
+++ b/platform_arm64.go
@@ -46,7 +46,7 @@ type MacPlatformConfigurationOption func(*MacPlatformConfiguration)
 func WithHardwareModel(m *MacHardwareModel) MacPlatformConfigurationOption {
 	return func(mpc *MacPlatformConfiguration) {
 		mpc.hardwareModel = m
-		C.setHardwareModelVZMacPlatformConfiguration(mpc.Ptr(), m.Ptr())
+		C.setHardwareModelVZMacPlatformConfiguration(mpc.ptr(), m.ptr())
 	}
 }
 
@@ -54,7 +54,7 @@ func WithHardwareModel(m *MacHardwareModel) MacPlatformConfigurationOption {
 func WithMachineIdentifier(m *MacMachineIdentifier) MacPlatformConfigurationOption {
 	return func(mpc *MacPlatformConfiguration) {
 		mpc.machineIdentifier = m
-		C.setMachineIdentifierVZMacPlatformConfiguration(mpc.Ptr(), m.Ptr())
+		C.setMachineIdentifierVZMacPlatformConfiguration(mpc.ptr(), m.ptr())
 	}
 }
 
@@ -62,7 +62,7 @@ func WithMachineIdentifier(m *MacMachineIdentifier) MacPlatformConfigurationOpti
 func WithAuxiliaryStorage(m *MacAuxiliaryStorage) MacPlatformConfigurationOption {
 	return func(mpc *MacPlatformConfiguration) {
 		mpc.auxiliaryStorage = m
-		C.setAuxiliaryStorageVZMacPlatformConfiguration(mpc.Ptr(), m.Ptr())
+		C.setAuxiliaryStorageVZMacPlatformConfiguration(mpc.ptr(), m.ptr())
 	}
 }
 

--- a/platform_arm64.go
+++ b/platform_arm64.go
@@ -77,7 +77,7 @@ func NewMacPlatformConfiguration(opts ...MacPlatformConfigurationOption) *MacPla
 		optFunc(platformConfig)
 	}
 	runtime.SetFinalizer(platformConfig, func(self *MacPlatformConfiguration) {
-		self.Release()
+		self.release()
 	})
 	return platformConfig
 }

--- a/pointing_device.go
+++ b/pointing_device.go
@@ -37,7 +37,7 @@ func NewUSBScreenCoordinatePointingDeviceConfiguration() *USBScreenCoordinatePoi
 		},
 	}
 	runtime.SetFinalizer(config, func(self *USBScreenCoordinatePointingDeviceConfiguration) {
-		self.Release()
+		self.release()
 	})
 	return config
 }

--- a/pointing_device.go
+++ b/pointing_device.go
@@ -32,9 +32,7 @@ var _ PointingDeviceConfiguration = (*USBScreenCoordinatePointingDeviceConfigura
 // NewUSBScreenCoordinatePointingDeviceConfiguration creates a new USBScreenCoordinatePointingDeviceConfiguration.
 func NewUSBScreenCoordinatePointingDeviceConfiguration() *USBScreenCoordinatePointingDeviceConfiguration {
 	config := &USBScreenCoordinatePointingDeviceConfiguration{
-		pointer: pointer{
-			ptr: C.newVZUSBScreenCoordinatePointingDeviceConfiguration(),
-		},
+		pointer: newPointer(C.newVZUSBScreenCoordinatePointingDeviceConfiguration()),
 	}
 	runtime.SetFinalizer(config, func(self *USBScreenCoordinatePointingDeviceConfiguration) {
 		self.release()

--- a/shared_folder.go
+++ b/shared_folder.go
@@ -35,9 +35,7 @@ func NewVirtioFileSystemDeviceConfiguration(tag string) *VirtioFileSystemDeviceC
 	tagChar := charWithGoString(tag)
 	defer tagChar.Free()
 	fsdConfig := &VirtioFileSystemDeviceConfiguration{
-		pointer: pointer{
-			ptr: C.newVZVirtioFileSystemDeviceConfiguration(tagChar.CString()),
-		},
+		pointer: newPointer(C.newVZVirtioFileSystemDeviceConfiguration(tagChar.CString())),
 	}
 	runtime.SetFinalizer(fsdConfig, func(self *VirtioFileSystemDeviceConfiguration) {
 		self.release()
@@ -60,9 +58,7 @@ func NewSharedDirectory(dirPath string, readOnly bool) *SharedDirectory {
 	dirPathChar := charWithGoString(dirPath)
 	defer dirPathChar.Free()
 	sd := &SharedDirectory{
-		pointer: pointer{
-			ptr: C.newVZSharedDirectory(dirPathChar.CString(), C.bool(readOnly)),
-		},
+		pointer: newPointer(C.newVZSharedDirectory(dirPathChar.CString(), C.bool(readOnly))),
 	}
 	runtime.SetFinalizer(sd, func(self *SharedDirectory) {
 		self.release()
@@ -93,9 +89,7 @@ type SingleDirectoryShare struct {
 // NewSingleDirectoryShare creates a new single directory share.
 func NewSingleDirectoryShare(share *SharedDirectory) *SingleDirectoryShare {
 	config := &SingleDirectoryShare{
-		pointer: pointer{
-			ptr: C.newVZSingleDirectoryShare(share.Ptr()),
-		},
+		pointer: newPointer(C.newVZSingleDirectoryShare(share.Ptr())),
 	}
 	runtime.SetFinalizer(config, func(self *SingleDirectoryShare) {
 		self.release()
@@ -120,9 +114,7 @@ func NewMultipleDirectoryShare(shares map[string]*SharedDirectory) *MultipleDire
 	dict := convertToNSMutableDictionary(directories)
 
 	config := &MultipleDirectoryShare{
-		pointer: pointer{
-			ptr: C.newVZMultipleDirectoryShare(dict.Ptr()),
-		},
+		pointer: newPointer(C.newVZMultipleDirectoryShare(dict.Ptr())),
 	}
 	runtime.SetFinalizer(config, func(self *SingleDirectoryShare) {
 		self.release()

--- a/shared_folder.go
+++ b/shared_folder.go
@@ -45,7 +45,7 @@ func NewVirtioFileSystemDeviceConfiguration(tag string) *VirtioFileSystemDeviceC
 
 // SetDirectoryShare sets the directory share associated with this configuration.
 func (c *VirtioFileSystemDeviceConfiguration) SetDirectoryShare(share DirectoryShare) {
-	C.setVZVirtioFileSystemDeviceConfigurationShare(c.Ptr(), share.Ptr())
+	C.setVZVirtioFileSystemDeviceConfigurationShare(c.ptr(), share.ptr())
 }
 
 // SharedDirectory is a shared directory.
@@ -89,7 +89,7 @@ type SingleDirectoryShare struct {
 // NewSingleDirectoryShare creates a new single directory share.
 func NewSingleDirectoryShare(share *SharedDirectory) *SingleDirectoryShare {
 	config := &SingleDirectoryShare{
-		pointer: newPointer(C.newVZSingleDirectoryShare(share.Ptr())),
+		pointer: newPointer(C.newVZSingleDirectoryShare(share.ptr())),
 	}
 	runtime.SetFinalizer(config, func(self *SingleDirectoryShare) {
 		self.release()
@@ -114,7 +114,7 @@ func NewMultipleDirectoryShare(shares map[string]*SharedDirectory) *MultipleDire
 	dict := convertToNSMutableDictionary(directories)
 
 	config := &MultipleDirectoryShare{
-		pointer: newPointer(C.newVZMultipleDirectoryShare(dict.Ptr())),
+		pointer: newPointer(C.newVZMultipleDirectoryShare(dict.ptr())),
 	}
 	runtime.SetFinalizer(config, func(self *SingleDirectoryShare) {
 		self.release()

--- a/shared_folder.go
+++ b/shared_folder.go
@@ -40,7 +40,7 @@ func NewVirtioFileSystemDeviceConfiguration(tag string) *VirtioFileSystemDeviceC
 		},
 	}
 	runtime.SetFinalizer(fsdConfig, func(self *VirtioFileSystemDeviceConfiguration) {
-		self.Release()
+		self.release()
 	})
 	return fsdConfig
 }
@@ -65,7 +65,7 @@ func NewSharedDirectory(dirPath string, readOnly bool) *SharedDirectory {
 		},
 	}
 	runtime.SetFinalizer(sd, func(self *SharedDirectory) {
-		self.Release()
+		self.release()
 	})
 	return sd
 }
@@ -98,7 +98,7 @@ func NewSingleDirectoryShare(share *SharedDirectory) *SingleDirectoryShare {
 		},
 	}
 	runtime.SetFinalizer(config, func(self *SingleDirectoryShare) {
-		self.Release()
+		self.release()
 	})
 	return config
 }
@@ -125,7 +125,7 @@ func NewMultipleDirectoryShare(shares map[string]*SharedDirectory) *MultipleDire
 		},
 	}
 	runtime.SetFinalizer(config, func(self *SingleDirectoryShare) {
-		self.Release()
+		self.release()
 	})
 	return config
 }

--- a/socket.go
+++ b/socket.go
@@ -79,14 +79,14 @@ func newVirtioSocketDevice(ptr, dispatchQueue unsafe.Pointer) *VirtioSocketDevic
 //
 // see: https://developer.apple.com/documentation/virtualization/vzvirtiosocketdevice/3656679-setsocketlistener?language=objc
 func (v *VirtioSocketDevice) SetSocketListenerForPort(listener *VirtioSocketListener, port uint32) {
-	C.VZVirtioSocketDevice_setSocketListenerForPort(v.Ptr(), v.dispatchQueue, listener.Ptr(), C.uint32_t(port))
+	C.VZVirtioSocketDevice_setSocketListenerForPort(v.ptr(), v.dispatchQueue, listener.ptr(), C.uint32_t(port))
 }
 
 // RemoveSocketListenerForPort removes the listener object from the specfied port.
 //
 // see: https://developer.apple.com/documentation/virtualization/vzvirtiosocketdevice/3656678-removesocketlistenerforport?language=objc
 func (v *VirtioSocketDevice) RemoveSocketListenerForPort(listener *VirtioSocketListener, port uint32) {
-	C.VZVirtioSocketDevice_removeSocketListenerForPort(v.Ptr(), v.dispatchQueue, C.uint32_t(port))
+	C.VZVirtioSocketDevice_removeSocketListenerForPort(v.ptr(), v.dispatchQueue, C.uint32_t(port))
 }
 
 //export connectionHandler
@@ -112,7 +112,7 @@ func connectionHandler(connPtr, errPtr, cgoHandlerPtr unsafe.Pointer) {
 // see: https://developer.apple.com/documentation/virtualization/vzvirtiosocketdevice/3656677-connecttoport?language=objc
 func (v *VirtioSocketDevice) ConnectToPort(port uint32, fn func(conn *VirtioSocketConnection, err error)) {
 	cgoHandler := cgo.NewHandle(fn)
-	C.VZVirtioSocketDevice_connectToPort(v.Ptr(), v.dispatchQueue, C.uint32_t(port), unsafe.Pointer(&cgoHandler))
+	C.VZVirtioSocketDevice_connectToPort(v.ptr(), v.dispatchQueue, C.uint32_t(port), unsafe.Pointer(&cgoHandler))
 }
 
 // VirtioSocketListener a struct that listens for port-based connection requests from the guest operating system.

--- a/socket.go
+++ b/socket.go
@@ -46,9 +46,7 @@ type VirtioSocketDeviceConfiguration struct {
 // NewVirtioSocketDeviceConfiguration creates a new VirtioSocketDeviceConfiguration.
 func NewVirtioSocketDeviceConfiguration() *VirtioSocketDeviceConfiguration {
 	config := &VirtioSocketDeviceConfiguration{
-		pointer: pointer{
-			ptr: C.newVZVirtioSocketDeviceConfiguration(),
-		},
+		pointer: newPointer(C.newVZVirtioSocketDeviceConfiguration()),
 	}
 	runtime.SetFinalizer(config, func(self *VirtioSocketDeviceConfiguration) {
 		self.release()
@@ -69,9 +67,7 @@ type VirtioSocketDevice struct {
 func newVirtioSocketDevice(ptr, dispatchQueue unsafe.Pointer) *VirtioSocketDevice {
 	socketDevice := &VirtioSocketDevice{
 		dispatchQueue: dispatchQueue,
-		pointer: pointer{
-			ptr: ptr,
-		},
+		pointer:       newPointer(ptr),
 	}
 	runtime.SetFinalizer(socketDevice, func(self *VirtioSocketDevice) {
 		self.release()
@@ -140,9 +136,7 @@ var shouldAcceptNewConnectionHandlers = map[unsafe.Pointer]func(conn *VirtioSock
 func NewVirtioSocketListener(handler func(conn *VirtioSocketConnection, err error)) *VirtioSocketListener {
 	ptr := C.newVZVirtioSocketListener()
 	listener := &VirtioSocketListener{
-		pointer: pointer{
-			ptr: ptr,
-		},
+		pointer: newPointer(ptr),
 	}
 
 	dupCh := make(chan dup, 1)

--- a/socket.go
+++ b/socket.go
@@ -51,7 +51,7 @@ func NewVirtioSocketDeviceConfiguration() *VirtioSocketDeviceConfiguration {
 		},
 	}
 	runtime.SetFinalizer(config, func(self *VirtioSocketDeviceConfiguration) {
-		self.Release()
+		self.release()
 	})
 	return config
 }
@@ -74,7 +74,7 @@ func newVirtioSocketDevice(ptr, dispatchQueue unsafe.Pointer) *VirtioSocketDevic
 		},
 	}
 	runtime.SetFinalizer(socketDevice, func(self *VirtioSocketDevice) {
-		self.Release()
+		self.release()
 	})
 	return socketDevice
 }
@@ -161,7 +161,7 @@ func NewVirtioSocketListener(handler func(conn *VirtioSocketConnection, err erro
 	}
 
 	runtime.SetFinalizer(listener, func(self *VirtioSocketListener) {
-		self.Release()
+		self.release()
 	})
 	return listener
 }

--- a/storage.go
+++ b/storage.go
@@ -59,7 +59,7 @@ func NewDiskImageStorageDeviceAttachment(diskPath string, readOnly bool) (*DiskI
 		return nil, err
 	}
 	runtime.SetFinalizer(attachment, func(self *DiskImageStorageDeviceAttachment) {
-		self.Release()
+		self.release()
 	})
 	return attachment, nil
 }
@@ -103,7 +103,7 @@ func NewVirtioBlockDeviceConfiguration(attachment StorageDeviceAttachment) *Virt
 		},
 	}
 	runtime.SetFinalizer(config, func(self *VirtioBlockDeviceConfiguration) {
-		self.Release()
+		self.release()
 	})
 	return config
 }

--- a/storage.go
+++ b/storage.go
@@ -42,7 +42,7 @@ type DiskImageStorageDeviceAttachment struct {
 // - readOnly if YES, the device attachment is read-only, otherwise the device can write data to the disk image.
 func NewDiskImageStorageDeviceAttachment(diskPath string, readOnly bool) (*DiskImageStorageDeviceAttachment, error) {
 	nserr := newNSErrorAsNil()
-	nserrPtr := nserr.Ptr()
+	nserrPtr := nserr.ptr()
 
 	diskPathChar := charWithGoString(diskPath)
 	defer diskPathChar.Free()
@@ -96,7 +96,7 @@ type VirtioBlockDeviceConfiguration struct {
 func NewVirtioBlockDeviceConfiguration(attachment StorageDeviceAttachment) *VirtioBlockDeviceConfiguration {
 	config := &VirtioBlockDeviceConfiguration{
 		pointer: newPointer(C.newVZVirtioBlockDeviceConfiguration(
-			attachment.Ptr(),
+			attachment.ptr(),
 		),
 		),
 	}

--- a/storage.go
+++ b/storage.go
@@ -47,13 +47,12 @@ func NewDiskImageStorageDeviceAttachment(diskPath string, readOnly bool) (*DiskI
 	diskPathChar := charWithGoString(diskPath)
 	defer diskPathChar.Free()
 	attachment := &DiskImageStorageDeviceAttachment{
-		pointer: pointer{
-			ptr: C.newVZDiskImageStorageDeviceAttachment(
-				diskPathChar.CString(),
-				C.bool(readOnly),
-				&nserrPtr,
-			),
-		},
+		pointer: newPointer(C.newVZDiskImageStorageDeviceAttachment(
+			diskPathChar.CString(),
+			C.bool(readOnly),
+			&nserrPtr,
+		),
+		),
 	}
 	if err := newNSError(nserrPtr); err != nil {
 		return nil, err
@@ -96,11 +95,10 @@ type VirtioBlockDeviceConfiguration struct {
 // - attachment The storage device attachment. This defines how the virtualized device operates on the host side.
 func NewVirtioBlockDeviceConfiguration(attachment StorageDeviceAttachment) *VirtioBlockDeviceConfiguration {
 	config := &VirtioBlockDeviceConfiguration{
-		pointer: pointer{
-			ptr: C.newVZVirtioBlockDeviceConfiguration(
-				attachment.Ptr(),
-			),
-		},
+		pointer: newPointer(C.newVZVirtioBlockDeviceConfiguration(
+			attachment.Ptr(),
+		),
+		),
 	}
 	runtime.SetFinalizer(config, func(self *VirtioBlockDeviceConfiguration) {
 		self.release()

--- a/virtualization.go
+++ b/virtualization.go
@@ -105,7 +105,7 @@ func NewVirtualMachine(config *VirtualMachineConfiguration) *VirtualMachine {
 	v := &VirtualMachine{
 		id: cs.String(),
 		pointer: newPointer(C.newVZVirtualMachineWithDispatchQueue(
-			config.Ptr(),
+			config.ptr(),
 			dispatchQueue,
 			unsafe.Pointer(&status),
 		),
@@ -130,7 +130,7 @@ func NewVirtualMachine(config *VirtualMachineConfiguration) *VirtualMachine {
 // see: https://developer.apple.com/documentation/virtualization/vzvirtualmachine/3656702-socketdevices?language=objc
 func (v *VirtualMachine) SocketDevices() []*VirtioSocketDevice {
 	nsarray := &nsArray{
-		pointer: newPointer(C.VZVirtualMachine_socketDevices(v.Ptr())),
+		pointer: newPointer(C.VZVirtualMachine_socketDevices(v.ptr())),
 	}
 	ptrs := nsarray.ToPointerSlice()
 	socketDevices := make([]*VirtioSocketDevice, len(ptrs))
@@ -176,27 +176,27 @@ func (v *VirtualMachine) StateChangedNotify() <-chan VirtualMachineState {
 
 // CanStart returns true if the machine is in a state that can be started.
 func (v *VirtualMachine) CanStart() bool {
-	return bool(C.vmCanStart(v.Ptr(), v.dispatchQueue))
+	return bool(C.vmCanStart(v.ptr(), v.dispatchQueue))
 }
 
 // CanPause returns true if the machine is in a state that can be paused.
 func (v *VirtualMachine) CanPause() bool {
-	return bool(C.vmCanPause(v.Ptr(), v.dispatchQueue))
+	return bool(C.vmCanPause(v.ptr(), v.dispatchQueue))
 }
 
 // CanResume returns true if the machine is in a state that can be resumed.
 func (v *VirtualMachine) CanResume() bool {
-	return (bool)(C.vmCanResume(v.Ptr(), v.dispatchQueue))
+	return (bool)(C.vmCanResume(v.ptr(), v.dispatchQueue))
 }
 
 // CanRequestStop returns whether the machine is in a state where the guest can be asked to stop.
 func (v *VirtualMachine) CanRequestStop() bool {
-	return (bool)(C.vmCanRequestStop(v.Ptr(), v.dispatchQueue))
+	return (bool)(C.vmCanRequestStop(v.ptr(), v.dispatchQueue))
 }
 
 // CanStop returns whether the machine is in a state that can be stopped.
 func (v *VirtualMachine) CanStop() bool {
-	return (bool)(C.vmCanStop(v.Ptr(), v.dispatchQueue))
+	return (bool)(C.vmCanStop(v.ptr(), v.dispatchQueue))
 }
 
 //export virtualMachineCompletionHandler
@@ -228,7 +228,7 @@ func (v *VirtualMachine) Start(fn func(error)) {
 	h, done := makeHandler(fn)
 	handler := cgo.NewHandle(h)
 	defer handler.Delete()
-	C.startWithCompletionHandler(v.Ptr(), v.dispatchQueue, unsafe.Pointer(&handler))
+	C.startWithCompletionHandler(v.ptr(), v.dispatchQueue, unsafe.Pointer(&handler))
 	<-done
 }
 
@@ -240,7 +240,7 @@ func (v *VirtualMachine) Pause(fn func(error)) {
 	h, done := makeHandler(fn)
 	handler := cgo.NewHandle(h)
 	defer handler.Delete()
-	C.pauseWithCompletionHandler(v.Ptr(), v.dispatchQueue, unsafe.Pointer(&handler))
+	C.pauseWithCompletionHandler(v.ptr(), v.dispatchQueue, unsafe.Pointer(&handler))
 	<-done
 }
 
@@ -252,7 +252,7 @@ func (v *VirtualMachine) Resume(fn func(error)) {
 	h, done := makeHandler(fn)
 	handler := cgo.NewHandle(h)
 	defer handler.Delete()
-	C.resumeWithCompletionHandler(v.Ptr(), v.dispatchQueue, unsafe.Pointer(&handler))
+	C.resumeWithCompletionHandler(v.ptr(), v.dispatchQueue, unsafe.Pointer(&handler))
 	<-done
 }
 
@@ -262,8 +262,8 @@ func (v *VirtualMachine) Resume(fn func(error)) {
 // Returns true if the request was made successfully.
 func (v *VirtualMachine) RequestStop() (bool, error) {
 	nserr := newNSErrorAsNil()
-	nserrPtr := nserr.Ptr()
-	ret := (bool)(C.requestStopVirtualMachine(v.Ptr(), v.dispatchQueue, &nserrPtr))
+	nserrPtr := nserr.ptr()
+	ret := (bool)(C.requestStopVirtualMachine(v.ptr(), v.dispatchQueue, &nserrPtr))
 	if err := newNSError(nserrPtr); err != nil {
 		return ret, err
 	}
@@ -281,7 +281,7 @@ func (v *VirtualMachine) Stop(fn func(error)) {
 	h, done := makeHandler(fn)
 	handler := cgo.NewHandle(h)
 	defer handler.Delete()
-	C.stopWithCompletionHandler(v.Ptr(), v.dispatchQueue, unsafe.Pointer(&handler))
+	C.stopWithCompletionHandler(v.ptr(), v.dispatchQueue, unsafe.Pointer(&handler))
 	<-done
 }
 
@@ -289,5 +289,5 @@ func (v *VirtualMachine) Stop(fn func(error)) {
 //
 // You must to call runtime.LockOSThread before calling this method.
 func (v *VirtualMachine) StartGraphicApplication(width, height float64) {
-	C.startVirtualMachineWindow(v.Ptr(), C.double(width), C.double(height))
+	C.startVirtualMachineWindow(v.ptr(), C.double(width), C.double(height))
 }

--- a/virtualization.go
+++ b/virtualization.go
@@ -118,7 +118,7 @@ func NewVirtualMachine(config *VirtualMachineConfiguration) *VirtualMachine {
 	runtime.SetFinalizer(v, func(self *VirtualMachine) {
 		self.status.Delete()
 		releaseDispatch(self.dispatchQueue)
-		self.Release()
+		self.release()
 	})
 	return v
 }

--- a/virtualization.go
+++ b/virtualization.go
@@ -130,12 +130,12 @@ func NewVirtualMachine(config *VirtualMachineConfiguration) *VirtualMachine {
 // it will always return VirtioSocketDevice.
 // see: https://developer.apple.com/documentation/virtualization/vzvirtualmachine/3656702-socketdevices?language=objc
 func (v *VirtualMachine) SocketDevices() []*VirtioSocketDevice {
-	nsArray := &NSArray{
+	nsarray := &nsArray{
 		pointer: pointer{
 			ptr: C.VZVirtualMachine_socketDevices(v.Ptr()),
 		},
 	}
-	ptrs := nsArray.ToPointerSlice()
+	ptrs := nsarray.ToPointerSlice()
 	socketDevices := make([]*VirtioSocketDevice, len(ptrs))
 	for i, ptr := range ptrs {
 		socketDevices[i] = newVirtioSocketDevice(ptr, v.dispatchQueue)

--- a/virtualization.go
+++ b/virtualization.go
@@ -104,13 +104,12 @@ func NewVirtualMachine(config *VirtualMachineConfiguration) *VirtualMachine {
 
 	v := &VirtualMachine{
 		id: cs.String(),
-		pointer: pointer{
-			ptr: C.newVZVirtualMachineWithDispatchQueue(
-				config.Ptr(),
-				dispatchQueue,
-				unsafe.Pointer(&status),
-			),
-		},
+		pointer: newPointer(C.newVZVirtualMachineWithDispatchQueue(
+			config.Ptr(),
+			dispatchQueue,
+			unsafe.Pointer(&status),
+		),
+		),
 		dispatchQueue: dispatchQueue,
 		status:        status,
 	}
@@ -131,9 +130,7 @@ func NewVirtualMachine(config *VirtualMachineConfiguration) *VirtualMachine {
 // see: https://developer.apple.com/documentation/virtualization/vzvirtualmachine/3656702-socketdevices?language=objc
 func (v *VirtualMachine) SocketDevices() []*VirtioSocketDevice {
 	nsarray := &nsArray{
-		pointer: pointer{
-			ptr: C.VZVirtualMachine_socketDevices(v.Ptr()),
-		},
+		pointer: newPointer(C.VZVirtualMachine_socketDevices(v.Ptr())),
 	}
 	ptrs := nsarray.ToPointerSlice()
 	socketDevices := make([]*VirtioSocketDevice, len(ptrs))

--- a/virtualization_arm64.go
+++ b/virtualization_arm64.go
@@ -50,7 +50,7 @@ func NewMacHardwareModelWithData(b []byte) *MacHardwareModel {
 	)
 	ret := newMacHardwareModel(ptr)
 	runtime.SetFinalizer(ret, func(self *MacHardwareModel) {
-		self.Release()
+		self.release()
 	})
 	return ret
 }
@@ -423,8 +423,8 @@ func NewMacOSInstaller(vm *VirtualMachine, restoreImageIpsw string) *MacOSInstal
 	}
 	ret.setFractionCompleted(0)
 	runtime.SetFinalizer(ret, func(self *MacOSInstaller) {
-		self.observerPointer.Release()
-		self.Release()
+		self.observerPointer.release()
+		self.release()
 	})
 	return ret
 }

--- a/virtualization_arm64.go
+++ b/virtualization_arm64.go
@@ -144,10 +144,10 @@ func WithCreatingStorage(hardwareModel *MacHardwareModel) NewMacAuxiliaryStorage
 		defer cpath.Free()
 
 		nserr := newNSErrorAsNil()
-		nserrPtr := nserr.Ptr()
+		nserrPtr := nserr.ptr()
 		mas.pointer = newPointer(C.newVZMacAuxiliaryStorageWithCreating(
 			cpath.CString(),
-			hardwareModel.Ptr(),
+			hardwareModel.ptr(),
 			&nserrPtr,
 		),
 		)
@@ -405,7 +405,7 @@ func NewMacOSInstaller(vm *VirtualMachine, restoreImageIpsw string) *MacOSInstal
 	cs := charWithGoString(restoreImageIpsw)
 	defer cs.Free()
 	ret := &MacOSInstaller{
-		pointer:         newPointer(C.newVZMacOSInstaller(vm.Ptr(), vm.dispatchQueue, cs.CString())),
+		pointer:         newPointer(C.newVZMacOSInstaller(vm.ptr(), vm.dispatchQueue, cs.CString())),
 		observerPointer: newPointer(C.newProgressObserverVZMacOSInstaller()),
 		vm:              vm,
 		doneCh:          make(chan struct{}),
@@ -461,9 +461,9 @@ func (m *MacOSInstaller) Install(ctx context.Context) error {
 		})
 
 		C.installByVZMacOSInstaller(
-			m.Ptr(),
+			m.ptr(),
 			m.vm.dispatchQueue,
-			m.observerPointer.Ptr(),
+			m.observerPointer.ptr(),
 			unsafe.Pointer(&completionHandler),
 			unsafe.Pointer(&fractionCompletedHandler),
 		)
@@ -471,7 +471,7 @@ func (m *MacOSInstaller) Install(ctx context.Context) error {
 
 	select {
 	case <-ctx.Done():
-		C.cancelInstallVZMacOSInstaller(m.Ptr())
+		C.cancelInstallVZMacOSInstaller(m.ptr())
 		return ctx.Err()
 	case <-m.doneCh:
 	}


### PR DESCRIPTION
At the moment, users of Code-Hex/vz can use the helper API (NSObject, NSError,
NSArray, pointer.Ptr(), pointer.Releases()) which was added for wrapping objc 
in go.
This API should not be used outside of vz implementation, and trying to
interact with it could even make vz misbehave.
This PR makes these helpers private to the vz package.