### PR TITLE
Retain errors in newVZFileSerialPortAttachment/newVZDiskImageStorageDeviceAttachment

### DIFF
--- a/error_test.go
+++ b/error_test.go
@@ -1,0 +1,12 @@
+package vz
+
+import (
+	"testing"
+)
+
+func TestNonExistingFileSerialPortAttachment(t *testing.T) {
+	_, err := NewFileSerialPortAttachment("/non/existing/path", false)
+	if err == nil {
+		t.Error("NewFileSerialPortAttachment should have returned an error")
+	}
+}

--- a/error_test.go
+++ b/error_test.go
@@ -10,3 +10,10 @@ func TestNonExistingFileSerialPortAttachment(t *testing.T) {
 		t.Error("NewFileSerialPortAttachment should have returned an error")
 	}
 }
+
+func TestNonExistingImageStorageDeviceAttachment(t *testing.T) {
+	_, err := NewDiskImageStorageDeviceAttachment("/non/existing/path", true)
+	if err == nil {
+		t.Error("NewDiskImageStorageDeviceAttachment should have returned an error")
+	}
+}

--- a/virtualization.m
+++ b/virtualization.m
@@ -693,10 +693,14 @@ void *newVZDiskImageStorageDeviceAttachment(const char *diskPath, bool readOnly,
         @autoreleasepool {
             NSString *diskPathNSString = [NSString stringWithUTF8String:diskPath];
             NSURL *diskURL = [NSURL fileURLWithPath:diskPathNSString];
+            NSError *_Nullable *_Nullable err = (NSError *_Nullable *_Nullable)error;
             ret = [[VZDiskImageStorageDeviceAttachment alloc]
                 initWithURL:diskURL
                    readOnly:(BOOL)readOnly
-                      error:(NSError *_Nullable *_Nullable)error];
+                      error:err];
+            if (err != nil && *err != nil) {
+                [*err retain];
+            }
         }
         return ret;
     }

--- a/virtualization.m
+++ b/virtualization.m
@@ -689,12 +689,16 @@ void *newVZVirtioBlockDeviceConfiguration(void *attachment)
 void *newVZDiskImageStorageDeviceAttachment(const char *diskPath, bool readOnly, void **error)
 {
     if (@available(macOS 11, *)) {
-        NSString *diskPathNSString = [NSString stringWithUTF8String:diskPath];
-        NSURL *diskURL = [NSURL fileURLWithPath:diskPathNSString];
-        return [[VZDiskImageStorageDeviceAttachment alloc]
-            initWithURL:diskURL
-               readOnly:(BOOL)readOnly
-                  error:(NSError *_Nullable *_Nullable)error];
+        VZDiskImageStorageDeviceAttachment *ret;
+        @autoreleasepool {
+            NSString *diskPathNSString = [NSString stringWithUTF8String:diskPath];
+            NSURL *diskURL = [NSURL fileURLWithPath:diskPathNSString];
+            ret = [[VZDiskImageStorageDeviceAttachment alloc]
+                initWithURL:diskURL
+                   readOnly:(BOOL)readOnly
+                      error:(NSError *_Nullable *_Nullable)error];
+        }
+        return ret;
     }
 
     RAISE_UNSUPPORTED_MACOS_EXCEPTION();

--- a/virtualization.m
+++ b/virtualization.m
@@ -518,10 +518,14 @@ void *newVZFileSerialPortAttachment(const char *filePath, bool shouldAppend, voi
         @autoreleasepool {
             NSString *filePathNSString = [NSString stringWithUTF8String:filePath];
             NSURL *fileURL = [NSURL fileURLWithPath:filePathNSString];
+            NSError *_Nullable *_Nullable err = (NSError *_Nullable *_Nullable)error;
             ret = [[VZFileSerialPortAttachment alloc]
                 initWithURL:fileURL
                      append:(BOOL)shouldAppend
-                      error:(NSError *_Nullable *_Nullable)error];
+                      error:err];
+            if (err != nil && *err != nil) {
+                [*err retain];
+            }
         }
         return ret;
     }


### PR DESCRIPTION
If newVZDiskImageStorageDeviceAttachment:initWithURL or
VZFileSerialPortAttachment:initWithURL return an error, we
need to call `retain` on it, otherwise it will be freed when exiting from the
@autoreleasepool block.

This PR also adds a small `error_test.go`. This test case crashes before the changes in this PR.
This fixes https://github.com/Code-Hex/vz/issues/56