### PR TITLE
vsock: Use net.FileConn to create VirtioSocketConnection

### DIFF
--- a/socket.go
+++ b/socket.go
@@ -200,11 +200,9 @@ func shouldAcceptNewConnectionHandler(listenerPtr, connPtr, devicePtr unsafe.Poi
 //
 // see: https://developer.apple.com/documentation/virtualization/vzvirtiosocketconnection?language=objc
 type VirtioSocketConnection struct {
-	sourcePort      uint32
-	destinationPort uint32
-	conn            net.Conn
-	laddr           net.Addr // local
-	raddr           net.Addr // remote
+	conn  net.Conn
+	laddr *Addr // local
+	raddr *Addr // remote
 }
 
 var _ net.Conn = (*VirtioSocketConnection)(nil)
@@ -218,9 +216,7 @@ func newVirtioSocketConnection(ptr unsafe.Pointer) (*VirtioSocketConnection, err
 		return nil, err
 	}
 	conn := &VirtioSocketConnection{
-		sourcePort:      (uint32)(vzVirtioSocketConnection.sourcePort),
-		destinationPort: (uint32)(vzVirtioSocketConnection.destinationPort),
-		conn:            rawConn,
+		conn: rawConn,
 		laddr: &Addr{
 			CID:  unix.VMADDR_CID_HOST,
 			Port: (uint32)(vzVirtioSocketConnection.destinationPort),
@@ -273,12 +269,12 @@ func (v *VirtioSocketConnection) SetWriteDeadline(t time.Time) error {
 
 // DestinationPort returns the destination port number of the connection.
 func (v *VirtioSocketConnection) DestinationPort() uint32 {
-	return v.destinationPort
+	return v.laddr.Port
 }
 
 // SourcePort returns the source port number of the connection.
 func (v *VirtioSocketConnection) SourcePort() uint32 {
-	return v.sourcePort
+	return v.raddr.Port
 }
 
 // Addr represents a network end point address for the vsock protocol.


### PR DESCRIPTION
Currently, newVirtioSocketConnection manually sets its objc file descriptor
to non-blocking, calls dup() on it, ... so that it matches what go expects
from a file descriptor.

go provides a helper doing all of this for us: net.FileConn() This commit
makes use of that helper. This will allow for more code simplifications in
the next commits.

However this removes vz.VirtioSocketConnection.FileDescriptor() since the
file descriptor was created internally by net.FileConn(). It would be
possible to keep it, but I'm not sure it's really useful. It would be more
consistent with other go APIs to add a File() method if we want to expose
this.

One side-effect of this change is to fix connections returned by 
ConnectToPort. At the moment, they are missing a call to Dup() for the file
descriptor they use. Without this, their file descriptor is closed too
early, and the connection cannot be used.

## Which issue(s) this PR fixes:

This fixes https://github.com/Code-Hex/vz/issues/54