### PR TITLE
fixed socket.go to do not release the shared devices pointer

### DIFF
--- a/socket.go
+++ b/socket.go
@@ -72,16 +72,12 @@ type VirtioSocketDevice struct {
 }
 
 func newVirtioSocketDevice(ptr, dispatchQueue unsafe.Pointer) *VirtioSocketDevice {
-	socketDevice := &VirtioSocketDevice{
+	return &VirtioSocketDevice{
 		dispatchQueue: dispatchQueue,
 		pointer: pointer{
 			ptr: ptr,
 		},
 	}
-	runtime.SetFinalizer(socketDevice, func(self *VirtioSocketDevice) {
-		self.Release()
-	})
-	return socketDevice
 }
 
 // SetSocketListenerForPort configures an object to monitor the specified port for new connections.
@@ -156,10 +152,6 @@ func NewVirtioSocketListener(handler func(conn *VirtioSocketConnection, err erro
 		go handler(conn, err)
 		return true // must be connected
 	}
-
-	runtime.SetFinalizer(listener, func(self *VirtioSocketListener) {
-		self.Release()
-	})
 	return listener, nil
 }
 


### PR DESCRIPTION

## Which issue(s) this PR fixes:

Fixes #13

## Additional documentation

@cfergeau suggested why this change is necessary.

> It is owned and maintained by the VMM. As a caller, we should not release it. If we do, we'll make it a dangling pointer.