### PR TITLE
Remove autoreleasepool from newVZFileSerialPortAttachment

### DIFF
--- a/error_test.go
+++ b/error_test.go
@@ -1,0 +1,12 @@
+package vz
+
+import (
+	"testing"
+)
+
+func TestNonExistingFileSerialPortAttachment(t *testing.T) {
+	_, err := NewFileSerialPortAttachment("/non/existing/path", false)
+	if err == nil {
+		t.Error("NewFileSerialPortAttachment should have returned an error")
+	}
+}

--- a/virtualization.m
+++ b/virtualization.m
@@ -509,15 +509,12 @@ void *newVZFileSerialPortAttachment(const char *filePath, bool shouldAppend, voi
 {
     if (@available(macOS 11, *)) {
         VZFileSerialPortAttachment *ret;
-        @autoreleasepool {
-            NSString *filePathNSString = [NSString stringWithUTF8String:filePath];
-            NSURL *fileURL = [NSURL fileURLWithPath:filePathNSString];
-            ret = [[VZFileSerialPortAttachment alloc]
-                initWithURL:fileURL
-                     append:(BOOL)shouldAppend
-                      error:(NSError *_Nullable *_Nullable)error];
-        }
-        return ret;
+        NSString *filePathNSString = [NSString stringWithUTF8String:filePath];
+        NSURL *fileURL = [NSURL fileURLWithPath:filePathNSString];
+        return [[VZFileSerialPortAttachment alloc]
+            initWithURL:fileURL
+                 append:(BOOL)shouldAppend
+                  error:(NSError *_Nullable *_Nullable)error];
     }
 
     RAISE_UNSUPPORTED_MACOS_EXCEPTION();


### PR DESCRIPTION
If we use autoreleasepool, the error returned from
VZFileSerialPortAttachment:initWithURL will be freed before
newVZFileSerialPortAttachment returns. We want the caller to be able to
use it.

This fixes TestNonExistingFileSerialPortAttachment() which is
crashing before this commit:

```
% go test .
fatal error: unexpected signal during runtime execution
[signal SIGSEGV: segmentation violation code=0x2 addr=0xcf6cce7eb130 pc=0x19e33a5a0]

runtime stack:
runtime.throw({0x100ce0ded?, 0x100ccf234?})
	/usr/local/go/src/runtime/panic.go:1047 +0x40 fp=0x16f293700 sp=0x16f2936d0 pc=0x100ba2870
runtime.sigpanic()
	/usr/local/go/src/runtime/signal_unix.go:819 +0x1e4 fp=0x16f293730 sp=0x16f293700 pc=0x100bb9754

goroutine 19 [syscall]:
runtime.cgocall(0x100ccf214, 0x14000040d98)
	/usr/local/go/src/runtime/cgocall.go:158 +0x54 fp=0x14000040d60 sp=0x14000040d20 pc=0x100b6fbc4
github.com/Code-Hex/vz/v2._Cfunc_convertNSError2Flat(0x6000022cb120)
	_cgo_gotypes.go:344 +0x3c fp=0x14000040d90 sp=0x14000040d60 pc=0x100ccc11c
github.com/Code-Hex/vz/v2.newNSError.func1(0x1010c0a68?)
	/Users/teuf/dev/vz/objcutil.go:234 +0x48 fp=0x14000040df0 sp=0x14000040d90 pc=0x100cccd58
github.com/Code-Hex/vz/v2.newNSError(0x0?)
	/Users/teuf/dev/vz/objcutil.go:234 +0x30 fp=0x14000040e80 sp=0x14000040df0 pc=0x100cccbe0
github.com/Code-Hex/vz/v2.NewFileSerialPortAttachment({0x100cd9765?, 0x100be659c?}, 0x68?)
	/Users/teuf/dev/vz/console.go:92 +0x104 fp=0x14000040f10 sp=0x14000040e80 pc=0x100ccc6c4
github.com/Code-Hex/vz/v2.TestNonExistingFileSerialPortAttachment(0x0?)
	/Users/teuf/dev/vz/error_test.go:10 +0x30 fp=0x14000040f60 sp=0x14000040f10 pc=0x100ccbf10
testing.tRunner(0x14000107040, 0x100d81878)
	/usr/local/go/src/testing/testing.go:1446 +0x10c fp=0x14000040fb0 sp=0x14000040f60 pc=0x100c2d10c
testing.(*T).Run.func1()
	/usr/local/go/src/testing/testing.go:1493 +0x2c fp=0x14000040fd0 sp=0x14000040fb0 pc=0x100c2de4c
runtime.goexit()
	/usr/local/go/src/runtime/asm_arm64.s:1165 +0x4 fp=0x14000040fd0 sp=0x14000040fd0 pc=0x100bd4834
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1493 +0x300
[snip]
```

This fixes https://github.com/Code-Hex/vz/issues/56


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/Code-Hex/vz/blob/master/CONTRIBUTING.md
2. Please create a new issue before creating this PR. However, You can continue it without creating issues if this PR fixes any documentations such as typo.
3. Do not send Pull Requests for major code changes. I am not motivated to review your code. Basically, I write the code.
-->

## Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional documentation

<!--
This section can be blank.
-->