### PR TITLE
added mechanisms for codesign when testing

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           go-version: ${{ matrix.go }}
       - name: Unit Test
-        run: go test ./...
+        run: make test
       - name: Build
         run: cd example/linux && make
       - name: vet

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
 .PHONY: fmt
 fmt:
 	@ls | grep -E '\.(h|m)$$' | xargs clang-format -i
+
+.PHONY: test
+test:
+	go test -exec "go run $(PWD)/cmd/codesign" -count=1 ./...

--- a/cmd/codesign/main.go
+++ b/cmd/codesign/main.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+var entitlements = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.virtualization</key>
+	<true/>
+</dict>
+</plist>`
+
+func main() {
+	if err := run(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func run() error {
+	f, err := os.CreateTemp("", "*.entitlements")
+	if err != nil {
+		return fmt.Errorf("failed to create temp file: %w", err)
+	}
+	defer f.Close()
+
+	if _, err := f.WriteString(entitlements); err != nil {
+		return fmt.Errorf("failed to write entitlements content: %w", err)
+	}
+
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("failed to close temp file: %w", err)
+	}
+	defer os.Remove(f.Name()) // clean up
+
+	cmd := exec.Command("codesign", "--entitlements", f.Name(), "-s", "-", os.Args[1])
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to do codesign(%q): %w",
+			strings.Join(
+				[]string{
+					"codesign", "--entitlements", f.Name(), "-s", "-", os.Args[1],
+				},
+				" ",
+			),
+			err,
+		)
+	}
+
+	testcmd := exec.Command(os.Args[1], os.Args[2:]...)
+	testcmd.Stdout = os.Stdout
+	testcmd.Stderr = os.Stderr
+	testcmd.Stdin = os.Stdin
+
+	return testcmd.Run()
+}

--- a/cmd/codesign/main.go
+++ b/cmd/codesign/main.go
@@ -29,6 +29,7 @@ func run() error {
 		return fmt.Errorf("failed to create temp file: %w", err)
 	}
 	defer f.Close()
+	defer os.Remove(f.Name()) // clean up
 
 	if _, err := f.WriteString(entitlements); err != nil {
 		return fmt.Errorf("failed to write entitlements content: %w", err)
@@ -37,7 +38,6 @@ func run() error {
 	if err := f.Close(); err != nil {
 		return fmt.Errorf("failed to close temp file: %w", err)
 	}
-	defer os.Remove(f.Name()) // clean up
 
 	cmd := exec.Command("codesign", "--entitlements", f.Name(), "-s", "-", os.Args[1])
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION


## Which issue(s) this PR fixes:

#69

## Additional documentation

This PR is required for integration testing. Running `make test` executes the test code after codesign.