### PR TITLE
Breaking changes some control methods

### DIFF
--- a/example/linux/main.go
+++ b/example/linux/main.go
@@ -162,13 +162,11 @@ func main() {
 	signalCh := make(chan os.Signal, 1)
 	signal.Notify(signalCh, syscall.SIGTERM)
 
-	errCh := make(chan error, 1)
+	if err := vm.Start(); err != nil {
+		log.Fatalf("Start virtual machine is failed: %s", err)
+	}
 
-	vm.Start(func(err error) {
-		if err != nil {
-			errCh <- err
-		}
-	})
+	errCh := make(chan error, 1)
 
 	for {
 		select {
@@ -192,7 +190,7 @@ func main() {
 		}
 	}
 
-	// vm.Resume(func(err error) {
-	// 	fmt.Println("in resume:", err)
-	// })
+	// if err := vm.Resume(); err != nil {
+	// 	log.Println("in resume:", err)
+	// }
 }

--- a/example/macOS/main.go
+++ b/example/macOS/main.go
@@ -50,13 +50,11 @@ func runVM(ctx context.Context) error {
 		return err
 	}
 
-	errCh := make(chan error, 1)
+	if err := vm.Start(); err != nil {
+		return err
+	}
 
-	vm.Start(func(err error) {
-		if err != nil {
-			errCh <- err
-		}
-	})
+	errCh := make(chan error, 1)
 
 	go func() {
 		for {
@@ -85,11 +83,9 @@ func runVM(ctx context.Context) error {
 			time.Sleep(time.Second * 3)
 			if i > 3 {
 				log.Println("call stop")
-				vm.Stop(func(err error) {
-					if err != nil {
-						log.Println("stop with error", err)
-					}
-				})
+				if err := vm.Stop(); err != nil {
+					log.Println("stop with error", err)
+				}
 			}
 		}
 		log.Println("finished cleanup")

--- a/issues_test.go
+++ b/issues_test.go
@@ -35,23 +35,15 @@ func TestIssue50(t *testing.T) {
 	}
 
 	t.Run("check for segmentation faults", func(t *testing.T) {
-		cases := map[string]func(){
-			"start handler": func() {
-				m.Start(func(err error) { _ = err == nil })
-			},
-			"pause handler": func() {
-				m.Pause(func(err error) { _ = err == nil })
-			},
-			"resume handler": func() {
-				m.Resume(func(err error) { _ = err == nil })
-			},
-			"stop handler": func() {
-				m.Stop(func(err error) { _ = err == nil })
-			},
+		cases := map[string]func() error{
+			"start handler":  m.Start,
+			"pause handler":  m.Pause,
+			"resume handler": m.Resume,
+			"stop handler":   m.Stop,
 		}
 		for name, run := range cases {
 			t.Run(name, func(t *testing.T) {
-				run()
+				_ = run()
 			})
 		}
 	})

--- a/osversion_test.go
+++ b/osversion_test.go
@@ -145,11 +145,7 @@ func TestAvailableVersion(t *testing.T) {
 				return err
 			},
 			"(*VirtualMachine).Stop": func() error {
-				var err error
-				(*VirtualMachine)(nil).Stop(func(e error) {
-					err = e
-				})
-				return err
+				return (*VirtualMachine)(nil).Stop()
 			},
 			"(*VirtualMachine).StartGraphicApplication": func() error {
 				return (*VirtualMachine)(nil).StartGraphicApplication(0, 0)

--- a/virtualization.go
+++ b/virtualization.go
@@ -95,9 +95,6 @@ type machineStatus struct {
 // The configuration must be valid. Validation can be performed at runtime with (*VirtualMachineConfiguration).Validate() method.
 // The configuration is copied by the initializer.
 //
-// A new dispatch queue will create when called this function.
-// Every operation on the virtual machine must be done on that queue. The callbacks and delegate methods are invoked on that queue.
-//
 // This is only supported on macOS 11 and newer, ErrUnsupportedOSVersion will
 // be returned on older versions.
 func NewVirtualMachine(config *VirtualMachineConfiguration) (*VirtualMachine, error) {


### PR DESCRIPTION
## Why

- Not simple.
- Some control methods have a callback parameter and invoke it on Objective-C's thread, not on the goroutine. If you call `runtime.Goexit` function on the callback, Go will throw "internal lockOSThread error" because the function terminates the goroutine that calls it, however, there is no goroutine in Objective-C's thread. Some `Fatal` function calls the `runtime.Goexit` function within it. It would be very difficult for users to understand this rule.

## Note

I recommend using `StateChangedNotify` instead of calling callback.