### PR TITLE
fixed VirtioSocketConnection impl

### DIFF
--- a/socket.go
+++ b/socket.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"runtime"
 	"runtime/cgo"
+	"time"
 	"unsafe"
 
 	"golang.org/x/sys/unix"
@@ -178,10 +179,12 @@ func shouldAcceptNewConnectionHandler(listenerPtr, connPtr, devicePtr unsafe.Poi
 //
 // see: https://developer.apple.com/documentation/virtualization/vzvirtiosocketconnection?language=objc
 type VirtioSocketConnection struct {
-	net.Conn
-	laddr *Addr // local
-	raddr *Addr // remote
+	rawConn net.Conn
+	laddr   *Addr // local
+	raddr   *Addr // remote
 }
+
+var _ net.Conn = (*VirtioSocketConnection)(nil)
 
 func newVirtioSocketConnection(ptr unsafe.Pointer) (*VirtioSocketConnection, error) {
 	vzVirtioSocketConnection := C.convertVZVirtioSocketConnection2Flat(ptr)
@@ -192,7 +195,7 @@ func newVirtioSocketConnection(ptr unsafe.Pointer) (*VirtioSocketConnection, err
 		return nil, err
 	}
 	conn := &VirtioSocketConnection{
-		Conn: rawConn,
+		rawConn: rawConn,
 		laddr: &Addr{
 			CID:  unix.VMADDR_CID_HOST,
 			Port: (uint32)(vzVirtioSocketConnection.destinationPort),
@@ -205,11 +208,43 @@ func newVirtioSocketConnection(ptr unsafe.Pointer) (*VirtioSocketConnection, err
 	return conn, nil
 }
 
+// Read reads data from connection of the vsock protocol.
+func (v *VirtioSocketConnection) Read(b []byte) (n int, err error) { return v.rawConn.Read(b) }
+
+// Write writes data to the connection of the vsock protocol.
+func (v *VirtioSocketConnection) Write(b []byte) (n int, err error) { return v.rawConn.Write(b) }
+
+// Close will be called when caused something error in socket.
+func (v *VirtioSocketConnection) Close() error {
+	return v.rawConn.Close()
+}
+
 // LocalAddr returns the local network address.
 func (v *VirtioSocketConnection) LocalAddr() net.Addr { return v.laddr }
 
 // RemoteAddr returns the remote network address.
 func (v *VirtioSocketConnection) RemoteAddr() net.Addr { return v.raddr }
+
+// SetDeadline sets the read and write deadlines associated
+// with the connection. It is equivalent to calling both
+// SetReadDeadline and SetWriteDeadline.
+func (v *VirtioSocketConnection) SetDeadline(t time.Time) error { return v.rawConn.SetDeadline(t) }
+
+// SetReadDeadline sets the deadline for future Read calls
+// and any currently-blocked Read call.
+// A zero value for t means Read will not time out.
+func (v *VirtioSocketConnection) SetReadDeadline(t time.Time) error {
+	return v.rawConn.SetReadDeadline(t)
+}
+
+// SetWriteDeadline sets the deadline for future Write calls
+// and any currently-blocked Write call.
+// Even if write times out, it may return n > 0, indicating that
+// some of the data was successfully written.
+// A zero value for t means Write will not time out.
+func (v *VirtioSocketConnection) SetWriteDeadline(t time.Time) error {
+	return v.rawConn.SetWriteDeadline(t)
+}
 
 // DestinationPort returns the destination port number of the connection.
 func (v *VirtioSocketConnection) DestinationPort() uint32 {


### PR DESCRIPTION
Because (*VirtioSocketConnection).Conn.LocalAddr() and (*VirtioSocketConnection).LocalAddr() are different. RemoteAddr method too.
