### PR TITLE
Add VZVirtualMachineConfiguration:SocketDevices and VZVirtualMachineConfiguration:NetworkDevices

### DIFF
--- a/configuration.go
+++ b/configuration.go
@@ -113,6 +113,22 @@ func (v *VirtualMachineConfiguration) SetNetworkDevicesVirtualMachineConfigurati
 	C.setNetworkDevicesVZVirtualMachineConfiguration(v.Ptr(), array.Ptr())
 }
 
+// NetworkDevices return the list of network device configuration set in this virtual machine configuration.
+// Return an empty array if no network device configuration is set.
+func (v *VirtualMachineConfiguration) NetworkDevices() []*VirtioNetworkDeviceConfiguration {
+	nsArray := &NSArray{
+		pointer: pointer{
+			ptr: C.networkDevicesVZVirtualMachineConfiguration(v.Ptr()),
+		},
+	}
+	ptrs := nsArray.ToPointerSlice()
+	networkDevices := make([]*VirtioNetworkDeviceConfiguration, len(ptrs))
+	for i, ptr := range ptrs {
+		networkDevices[i] = newVirtioNetworkDeviceConfiguration(ptr)
+	}
+	return networkDevices
+}
+
 // SetSerialPortsVirtualMachineConfiguration sets list of serial ports. Empty by default.
 func (v *VirtualMachineConfiguration) SetSerialPortsVirtualMachineConfiguration(cs []*VirtioConsoleDeviceSerialPortConfiguration) {
 	ptrs := make([]NSObject, len(cs))

--- a/configuration.go
+++ b/configuration.go
@@ -133,6 +133,22 @@ func (v *VirtualMachineConfiguration) SetSocketDevicesVirtualMachineConfiguratio
 	C.setSocketDevicesVZVirtualMachineConfiguration(v.Ptr(), array.Ptr())
 }
 
+// SocketDevices return the list of socket device configuration configured in this virtual machine configuration.
+// Return an empty array if no socket device configuration is set.
+func (v *VirtualMachineConfiguration) SocketDevices() []SocketDeviceConfiguration {
+	nsArray := &NSArray{
+		pointer: pointer{
+			ptr: C.socketDevicesVZVirtualMachineConfiguration(v.Ptr()),
+		},
+	}
+	ptrs := nsArray.ToPointerSlice()
+	socketDevices := make([]SocketDeviceConfiguration, len(ptrs))
+	for i, ptr := range ptrs {
+		socketDevices[i] = newVirtioSocketDeviceConfiguration(ptr)
+	}
+	return socketDevices
+}
+
 // SetStorageDevicesVirtualMachineConfiguration sets list of disk devices. Empty by default.
 func (v *VirtualMachineConfiguration) SetStorageDevicesVirtualMachineConfiguration(cs []StorageDeviceConfiguration) {
 	ptrs := make([]NSObject, len(cs))

--- a/issues_test.go
+++ b/issues_test.go
@@ -120,3 +120,31 @@ func TestIssue43(t *testing.T) {
 		}
 	})
 }
+
+func TestIssue81(t *testing.T) {
+	config := newTestConfig(t)
+
+	ok, err := config.Validate()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("failed to validate config")
+	}
+	vsockDevs := config.SocketDevices()
+	if len(vsockDevs) != 0 {
+		t.Errorf("unexpected number of virtio-vsock devices: got %d, expected 0", len(vsockDevs))
+	}
+
+	vsockDev, err := NewVirtioSocketDeviceConfiguration()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	config.SetSocketDevicesVirtualMachineConfiguration([]SocketDeviceConfiguration{vsockDev})
+
+	vsockDevs = config.SocketDevices()
+	if len(vsockDevs) != 1 {
+		t.Errorf("unexpected number of virtio-vsock devices: got %d, expected 1", len(vsockDevs))
+	}
+}

--- a/issues_test.go
+++ b/issues_test.go
@@ -13,6 +13,7 @@ func newTestConfig(t *testing.T) *VirtualMachineConfiguration {
 		t.Fatal(err)
 	}
 	defer f.Close()
+	defer os.Remove(f.Name())
 
 	bootloader, err := NewLinuxBootLoader(f.Name())
 	if err != nil {

--- a/issues_test.go
+++ b/issues_test.go
@@ -131,20 +131,46 @@ func TestIssue81(t *testing.T) {
 	if !ok {
 		t.Fatal("failed to validate config")
 	}
-	vsockDevs := config.SocketDevices()
-	if len(vsockDevs) != 0 {
-		t.Errorf("unexpected number of virtio-vsock devices: got %d, expected 0", len(vsockDevs))
-	}
 
-	vsockDev, err := NewVirtioSocketDeviceConfiguration()
-	if err != nil {
-		t.Fatal(err)
-	}
+	t.Run("SocketDevices", func(t *testing.T) {
+		vsockDevs := config.SocketDevices()
+		if len(vsockDevs) != 0 {
+			t.Errorf("unexpected number of virtio-vsock devices: got %d, expected 0", len(vsockDevs))
+		}
 
-	config.SetSocketDevicesVirtualMachineConfiguration([]SocketDeviceConfiguration{vsockDev})
+		vsockDev, err := NewVirtioSocketDeviceConfiguration()
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	vsockDevs = config.SocketDevices()
-	if len(vsockDevs) != 1 {
-		t.Errorf("unexpected number of virtio-vsock devices: got %d, expected 1", len(vsockDevs))
-	}
+		config.SetSocketDevicesVirtualMachineConfiguration([]SocketDeviceConfiguration{vsockDev})
+
+		vsockDevs = config.SocketDevices()
+		if len(vsockDevs) != 1 {
+			t.Errorf("unexpected number of virtio-vsock devices: got %d, expected 1", len(vsockDevs))
+		}
+	})
+
+	t.Run("NetworkDevices", func(t *testing.T) {
+		networkDevs := config.NetworkDevices()
+		if len(networkDevs) != 0 {
+			t.Errorf("unexpected number of virtio-net devices: got %d, expected 0", len(networkDevs))
+		}
+
+		nat, err := NewNATNetworkDeviceAttachment()
+		if err != nil {
+			t.Fatal(err)
+		}
+		networkDev, err := NewVirtioNetworkDeviceConfiguration(nat)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		config.SetNetworkDevicesVirtualMachineConfiguration([]*VirtioNetworkDeviceConfiguration{networkDev})
+
+		networkDevs = config.NetworkDevices()
+		if len(networkDevs) != 1 {
+			t.Errorf("unexpected number of virtio-vsock devices: got %d, expected 1", len(networkDevs))
+		}
+	})
 }

--- a/issues_test.go
+++ b/issues_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-func TestIssue50(t *testing.T) {
+func newTestConfig(t *testing.T) *VirtualMachineConfiguration {
 	f, err := os.CreateTemp("", "vmlinuz")
 	if err != nil {
 		t.Fatal(err)
@@ -22,6 +22,13 @@ func TestIssue50(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	return config
+}
+
+func TestIssue50(t *testing.T) {
+	config := newTestConfig(t)
+
 	ok, err := config.Validate()
 	if err != nil {
 		t.Fatal(err)

--- a/network.go
+++ b/network.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"os"
 	"runtime"
+	"unsafe"
 )
 
 // BridgedNetwork defines a network interface that bridges a physical interface with a virtual machine.
@@ -177,17 +178,23 @@ func NewVirtioNetworkDeviceConfiguration(attachment NetworkDeviceAttachment) (*V
 		return nil, ErrUnsupportedOSVersion
 	}
 
-	config := &VirtioNetworkDeviceConfiguration{
-		pointer: pointer{
-			ptr: C.newVZVirtioNetworkDeviceConfiguration(
-				attachment.Ptr(),
-			),
-		},
-	}
+	config := newVirtioNetworkDeviceConfiguration(
+		C.newVZVirtioNetworkDeviceConfiguration(
+			attachment.Ptr(),
+		),
+	)
 	runtime.SetFinalizer(config, func(self *VirtioNetworkDeviceConfiguration) {
 		self.Release()
 	})
 	return config, nil
+}
+
+func newVirtioNetworkDeviceConfiguration(ptr unsafe.Pointer) *VirtioNetworkDeviceConfiguration {
+	return &VirtioNetworkDeviceConfiguration{
+		pointer: pointer{
+			ptr: ptr,
+		},
+	}
 }
 
 func (v *VirtioNetworkDeviceConfiguration) SetMACAddress(macAddress *MACAddress) {

--- a/socket.go
+++ b/socket.go
@@ -51,15 +51,20 @@ func NewVirtioSocketDeviceConfiguration() (*VirtioSocketDeviceConfiguration, err
 		return nil, ErrUnsupportedOSVersion
 	}
 
-	config := &VirtioSocketDeviceConfiguration{
-		pointer: pointer{
-			ptr: C.newVZVirtioSocketDeviceConfiguration(),
-		},
-	}
+	config := newVirtioSocketDeviceConfiguration(C.newVZVirtioSocketDeviceConfiguration())
+
 	runtime.SetFinalizer(config, func(self *VirtioSocketDeviceConfiguration) {
 		self.Release()
 	})
 	return config, nil
+}
+
+func newVirtioSocketDeviceConfiguration(ptr unsafe.Pointer) *VirtioSocketDeviceConfiguration {
+	return &VirtioSocketDeviceConfiguration{
+		pointer: pointer{
+			ptr: ptr,
+		},
+	}
 }
 
 // VirtioSocketDevice a device that manages port-based connections between the guest system and the host computer.

--- a/virtualization.h
+++ b/virtualization.h
@@ -44,6 +44,7 @@ void setMemoryBalloonDevicesVZVirtualMachineConfiguration(void *config,
     void *memoryBalloonDevices);
 void setNetworkDevicesVZVirtualMachineConfiguration(void *config,
     void *networkDevices);
+void *networkDevicesVZVirtualMachineConfiguration(void *config);
 void setSerialPortsVZVirtualMachineConfiguration(void *config,
     void *serialPorts);
 void setSocketDevicesVZVirtualMachineConfiguration(void *config,

--- a/virtualization.h
+++ b/virtualization.h
@@ -48,6 +48,7 @@ void setSerialPortsVZVirtualMachineConfiguration(void *config,
     void *serialPorts);
 void setSocketDevicesVZVirtualMachineConfiguration(void *config,
     void *socketDevices);
+void *socketDevicesVZVirtualMachineConfiguration(void *config);
 void setStorageDevicesVZVirtualMachineConfiguration(void *config,
     void *storageDevices);
 void setDirectorySharingDevicesVZVirtualMachineConfiguration(void *config, void *directorySharingDevices);

--- a/virtualization.m
+++ b/virtualization.m
@@ -274,6 +274,18 @@ void setSocketDevicesVZVirtualMachineConfiguration(void *config,
 }
 
 /*!
+ @abstract Return the list of socket devices configurations for this VZVirtualMachineConfiguration. Return an empty array if no socket device configuration is set.
+ */
+void *socketDevicesVZVirtualMachineConfiguration(void *config)
+{
+    if (@available(macOS 11, *)) {
+        return [(VZVirtualMachineConfiguration *)config socketDevices]; // NSArray<VZSocketDeviceConfiguration *>
+    }
+
+    RAISE_UNSUPPORTED_MACOS_EXCEPTION();
+}
+
+/*!
  @abstract List of disk devices. Empty by default.
  @see VZVirtioBlockDeviceConfiguration
  */

--- a/virtualization.m
+++ b/virtualization.m
@@ -244,6 +244,18 @@ void setNetworkDevicesVZVirtualMachineConfiguration(void *config,
 }
 
 /*!
+ @abstract Return the list of network devices configurations for this VZVirtualMachineConfiguration. Return an empty array if no network device configuration is set.
+ */
+void *networkDevicesVZVirtualMachineConfiguration(void *config)
+{
+    if (@available(macOS 11, *)) {
+        return [(VZVirtualMachineConfiguration *)config networkDevices]; // NSArray<VZSocketDeviceConfiguration *>
+    }
+
+    RAISE_UNSUPPORTED_MACOS_EXCEPTION();
+}
+
+/*!
  @abstract List of serial ports. Empty by default.
  @see VZVirtioConsoleDeviceSerialPortConfiguration
  */


### PR DESCRIPTION
Since only a single VZVirtioSocketDevice is allowed per virtual machine 
instance, it's useful to be able to check whether one is already set or not
in the VZVirtualMachineConfiguration object.

This fixes https://github.com/Code-Hex/vz/issues/81



<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/Code-Hex/vz/blob/master/CONTRIBUTING.md
2. Please create a new issue before creating this PR. However, You can continue it without creating issues if this PR fixes any documentations such as typo.
3. Do not send Pull Requests for large (150 ~ lines) code changes. If so, I am not motivated to review your code. Basically, I write the code.
-->

## Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional documentation

<!--
This section can be blank.
-->