### PR TITLE
console: Don't return error for non-existing files

### DIFF
--- a/console.go
+++ b/console.go
@@ -88,9 +88,6 @@ func NewFileSerialPortAttachment(path string, shouldAppend bool) (*FileSerialPor
 	if macosMajorVersionLessThan(11) {
 		return nil, ErrUnsupportedOSVersion
 	}
-	if _, err := os.Stat(path); err != nil {
-		return nil, err
-	}
 
 	cpath := charWithGoString(path)
 	defer cpath.Free()

--- a/issues_test.go
+++ b/issues_test.go
@@ -93,11 +93,6 @@ func TestIssue43(t *testing.T) {
 		})
 
 		cases := map[string]func() error{
-			// This is also fixed issue #71
-			"NewFileSerialPortAttachment": func() error {
-				_, err := NewFileSerialPortAttachment(doesNotExists, false)
-				return err
-			},
 			"NewSharedDirectory": func() error {
 				_, err := NewSharedDirectory(doesNotExists, false)
 				return err

--- a/issues_test.go
+++ b/issues_test.go
@@ -99,7 +99,7 @@ func TestIssue43(t *testing.T) {
 				return err
 			},
 			"NewSharedDirectory": func() error {
-				_, err := NewFileSerialPortAttachment(doesNotExists, false)
+				_, err := NewSharedDirectory(doesNotExists, false)
 				return err
 			},
 			"NewDiskImageStorageDeviceAttachment": func() error {
@@ -113,7 +113,7 @@ func TestIssue43(t *testing.T) {
 				if err == nil {
 					t.Fatal("expected returns error")
 				}
-				if !errors.Is(err, os.ErrNotExist) {
+				if !errors.Is(err, ErrUnsupportedOSVersion) && !errors.Is(err, os.ErrNotExist) {
 					t.Errorf("want underlying error %q but got %q", os.ErrNotExist, err)
 				}
 			})


### PR DESCRIPTION
When using NewFileSerialPortAttachment(), the virtualization framework will
create the log file if it does not exist yet.
commit 117c12a added a file existence check to this API, which is incorrect.


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/Code-Hex/vz/blob/master/CONTRIBUTING.md
2. Please create a new issue before creating this PR. However, You can continue it without creating issues if this PR fixes any documentations such as typo.
3. Do not send Pull Requests for large (150 ~ lines) code changes. If so, I am not motivated to review your code. Basically, I write the code.
-->

Fixes #84