### PR TITLE
breaking change around VirtioSocketListener

### DIFF
--- a/osversion_test.go
+++ b/osversion_test.go
@@ -76,8 +76,8 @@ func TestAvailableVersion(t *testing.T) {
 				_, err := NewVirtioSocketDeviceConfiguration()
 				return err
 			},
-			"NewVirtioSocketListener": func() error {
-				_, err := NewVirtioSocketListener(nil)
+			"(*VirtioSocketDevice).Listen": func() error {
+				_, err := (*VirtioSocketDevice)(nil).Listen(1)
 				return err
 			},
 			"NewDiskImageStorageDeviceAttachment": func() error {

--- a/virtualization.h
+++ b/virtualization.h
@@ -13,7 +13,7 @@
 void virtualMachineCompletionHandler(void *cgoHandler, void *errPtr);
 void connectionHandler(void *connection, void *err, void *cgoHandlerPtr);
 void changeStateOnObserver(int state, void *cgoHandler);
-bool shouldAcceptNewConnectionHandler(void *listener, void *connection, void *socketDevice);
+bool shouldAcceptNewConnectionHandler(void *cgoHandler, void *connection, void *socketDevice);
 
 @interface Observer : NSObject
 - (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context;
@@ -21,6 +21,7 @@ bool shouldAcceptNewConnectionHandler(void *listener, void *connection, void *so
 
 /* VZVirtioSocketListener */
 @interface VZVirtioSocketListenerDelegateImpl : NSObject <VZVirtioSocketListenerDelegate>
+- (instancetype)initWithHandler:(void *)cgoHandler;
 - (BOOL)listener:(VZVirtioSocketListener *)listener shouldAcceptNewConnection:(VZVirtioSocketConnection *)connection fromSocketDevice:(VZVirtioSocketDevice *)socketDevice;
 @end
 
@@ -81,7 +82,7 @@ void *newVZVirtioSocketDeviceConfiguration();
 void *newVZMACAddress(const char *macAddress);
 void *newRandomLocallyAdministeredVZMACAddress();
 const char *getVZMACAddressString(void *macAddress);
-void *newVZVirtioSocketListener();
+void *newVZVirtioSocketListener(void *cgoHandlerPtr);
 void *newVZSharedDirectory(const char *dirPath, bool readOnly);
 void *newVZSingleDirectoryShare(void *sharedDirectory);
 void *newVZMultipleDirectoryShare(void *sharedDirectories);

--- a/virtualization.m
+++ b/virtualization.m
@@ -36,10 +36,20 @@ char *copyCString(NSString *nss)
 }
 @end
 
-@implementation VZVirtioSocketListenerDelegateImpl
+@implementation VZVirtioSocketListenerDelegateImpl {
+    void *_cgoHandler;
+}
+
+- (instancetype)initWithHandler:(void *)cgoHandler
+{
+    self = [super init];
+    _cgoHandler = cgoHandler;
+    return self;
+}
+
 - (BOOL)listener:(VZVirtioSocketListener *)listener shouldAcceptNewConnection:(VZVirtioSocketConnection *)connection fromSocketDevice:(VZVirtioSocketDevice *)socketDevice;
 {
-    return (BOOL)shouldAcceptNewConnectionHandler(listener, connection, socketDevice);
+    return (BOOL)shouldAcceptNewConnectionHandler(_cgoHandler, connection, socketDevice);
 }
 @end
 
@@ -743,11 +753,11 @@ void *newVZVirtioSocketDeviceConfiguration()
  @see VZVirtioSocketDevice
  @see VZVirtioSocketListenerDelegate
  */
-void *newVZVirtioSocketListener()
+void *newVZVirtioSocketListener(void *cgoHandlerPtr)
 {
     if (@available(macOS 11, *)) {
         VZVirtioSocketListener *ret = [[VZVirtioSocketListener alloc] init];
-        [ret setDelegate:[[VZVirtioSocketListenerDelegateImpl alloc] init]];
+        [ret setDelegate:[[VZVirtioSocketListenerDelegateImpl alloc] initWithHandler:cgoHandlerPtr]];
         return ret;
     }
 


### PR DESCRIPTION
## Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #73

## Additional documentation

Breaking changes around `VirtioSocketListener`. This is because using the methods provided in the virtualization.framework as they are in Go would be too much work. This implementation is cleaner as it eliminates the need to carry around both `VirtioSocketDevice` and `VirtioSocketListener` to cleanup listeners (need to call RemoveSocketListenerForPort).