### PR TITLE
breaking change ConnectToPort

### DIFF
--- a/socket.go
+++ b/socket.go
@@ -150,6 +150,7 @@ func (v *VirtioSocketDevice) Connect(port uint32) (*VirtioSocketConnection, erro
 	ch := make(chan connResults, 1)
 	cgoHandler := cgo.NewHandle(func(conn *VirtioSocketConnection, err error) {
 		ch <- connResults{conn, err}
+		close(ch)
 	})
 	C.VZVirtioSocketDevice_connectToPort(v.Ptr(), v.dispatchQueue, C.uint32_t(port), unsafe.Pointer(&cgoHandler))
 	result := <-ch

--- a/socket.go
+++ b/socket.go
@@ -97,10 +97,10 @@ func (v *VirtioSocketDevice) Listen(port uint32) (*VirtioSocketListener, error) 
 		return nil, ErrUnsupportedOSVersion
 	}
 
-	ch := make(chan accept, 1) // should I increase more caps?
+	ch := make(chan connResults, 1) // should I increase more caps?
 
 	handler := cgo.NewHandle(func(conn *VirtioSocketConnection, err error) {
-		ch <- accept{conn, err}
+		ch <- connResults{conn, err}
 	})
 	ptr := C.newVZVirtioSocketListener(
 		unsafe.Pointer(&handler),
@@ -139,20 +139,25 @@ func connectionHandler(connPtr, errPtr, cgoHandlerPtr unsafe.Pointer) {
 	}
 }
 
-// ConnectToPort Initiates a connection to the specified port of the guest operating system.
+// Connect Initiates a connection to the specified port of the guest operating system.
 //
 // This method initiates the connection asynchronously, and executes the completion handler when the results are available.
 // If the guest operating system doesn’t listen for connections to the specifed port, this method does nothing.
 //
 // For a successful connection, this method sets the sourcePort property of the resulting VZVirtioSocketConnection object to a random port number.
 // see: https://developer.apple.com/documentation/virtualization/vzvirtiosocketdevice/3656677-connecttoport?language=objc
-func (v *VirtioSocketDevice) ConnectToPort(port uint32, fn func(conn *VirtioSocketConnection, err error)) {
-	cgoHandler := cgo.NewHandle(fn)
+func (v *VirtioSocketDevice) Connect(port uint32) (*VirtioSocketConnection, error) {
+	ch := make(chan connResults, 1)
+	cgoHandler := cgo.NewHandle(func(conn *VirtioSocketConnection, err error) {
+		ch <- connResults{conn, err}
+	})
 	C.VZVirtioSocketDevice_connectToPort(v.Ptr(), v.dispatchQueue, C.uint32_t(port), unsafe.Pointer(&cgoHandler))
+	result := <-ch
 	runtime.KeepAlive(v)
+	return result.conn, result.err
 }
 
-type accept struct {
+type connResults struct {
 	conn *VirtioSocketConnection
 	err  error
 }
@@ -165,7 +170,7 @@ type VirtioSocketListener struct {
 	vsockDevice *VirtioSocketDevice
 	handler     cgo.Handle
 	port        uint32
-	acceptch    chan accept
+	acceptch    chan connResults
 	closeOnce   sync.Once
 }
 

--- a/virtualization.m
+++ b/virtualization.m
@@ -812,7 +812,7 @@ void VZVirtioSocketDevice_removeSocketListenerForPort(void *socketDevice, void *
 void VZVirtioSocketDevice_connectToPort(void *socketDevice, void *vmQueue, uint32_t port, void *cgoHandlerPtr)
 {
     if (@available(macOS 11, *)) {
-        dispatch_sync((dispatch_queue_t)vmQueue, ^{
+        dispatch_async((dispatch_queue_t)vmQueue, ^{
             [(VZVirtioSocketDevice *)socketDevice connectToPort:port
                                               completionHandler:^(VZVirtioSocketConnection *connection, NSError *err) {
                                                   connectionHandler(connection, err, cgoHandlerPtr);


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/Code-Hex/vz/blob/master/CONTRIBUTING.md
2. Please create a new issue before creating this PR. However, You can continue it without creating issues if this PR fixes any documentations such as typo.
3. Do not send Pull Requests for large (150 ~ lines) code changes. If so, I am not motivated to review your code. Basically, I write the code.
-->

## Which issue(s) this PR fixes:

Similar fixes #79

## Additional documentation

The handler passed here is not executed within the goroutine, so calls such as `Goexit` will result in an unintended ThreadLock. To prevent this, instead of receiving the connection in a callback, we return an internal duplicate of the file descriptor, preventing unintended callbacks from being executed

