### PR TITLE
addressed issue #101

### DIFF
--- a/audio.go
+++ b/audio.go
@@ -41,11 +41,11 @@ var _ AudioDeviceConfiguration = (*VirtioSoundDeviceConfiguration)(nil)
 
 // NewVirtioSoundDeviceConfiguration creates a new sound device configuration.
 //
-// This is only supported on macOS 12 and newer, ErrUnsupportedOSVersion will
-// be returned on older versions.
+// This is only supported on macOS 12 and newer, error will be returned
+// on older versions.
 func NewVirtioSoundDeviceConfiguration() (*VirtioSoundDeviceConfiguration, error) {
-	if macosMajorVersionLessThan(12) {
-		return nil, ErrUnsupportedOSVersion
+	if err := macOSAvailable(12); err != nil {
+		return nil, err
 	}
 	config := &VirtioSoundDeviceConfiguration{
 		pointer: objc.NewPointer(
@@ -93,11 +93,11 @@ var _ VirtioSoundDeviceStreamConfiguration = (*VirtioSoundDeviceHostInputStreamC
 
 // NewVirtioSoundDeviceHostInputStreamConfiguration creates a new PCM stream configuration of input audio data from host.
 //
-// This is only supported on macOS 12 and newer, ErrUnsupportedOSVersion will
-// be returned on older versions.
+// This is only supported on macOS 12 and newer, error will be returned
+// on older versions.
 func NewVirtioSoundDeviceHostInputStreamConfiguration() (*VirtioSoundDeviceHostInputStreamConfiguration, error) {
-	if macosMajorVersionLessThan(12) {
-		return nil, ErrUnsupportedOSVersion
+	if err := macOSAvailable(12); err != nil {
+		return nil, err
 	}
 	config := &VirtioSoundDeviceHostInputStreamConfiguration{
 		pointer: objc.NewPointer(
@@ -124,11 +124,11 @@ var _ VirtioSoundDeviceStreamConfiguration = (*VirtioSoundDeviceHostOutputStream
 
 // NewVirtioSoundDeviceHostOutputStreamConfiguration creates a new sounds device output stream configuration.
 //
-// This is only supported on macOS 12 and newer, ErrUnsupportedOSVersion will
-// be returned on older versions.
+// This is only supported on macOS 12 and newer, error will be returned
+// on older versions.
 func NewVirtioSoundDeviceHostOutputStreamConfiguration() (*VirtioSoundDeviceHostOutputStreamConfiguration, error) {
-	if macosMajorVersionLessThan(12) {
-		return nil, ErrUnsupportedOSVersion
+	if err := macOSAvailable(12); err != nil {
+		return nil, err
 	}
 	config := &VirtioSoundDeviceHostOutputStreamConfiguration{
 		pointer: objc.NewPointer(

--- a/bootloader.go
+++ b/bootloader.go
@@ -78,11 +78,11 @@ func WithInitrd(initrdPath string) LinuxBootLoaderOption {
 
 // NewLinuxBootLoader creates a LinuxBootLoader with the Linux kernel passed as Path.
 //
-// This is only supported on macOS 11 and newer, ErrUnsupportedOSVersion will
+// This is only supported on macOS 11 and newer, error will
 // be returned on older versions.
 func NewLinuxBootLoader(vmlinuz string, opts ...LinuxBootLoaderOption) (*LinuxBootLoader, error) {
-	if macosMajorVersionLessThan(11) {
-		return nil, ErrUnsupportedOSVersion
+	if err := macOSAvailable(11); err != nil {
+		return nil, err
 	}
 	if _, err := os.Stat(vmlinuz); err != nil {
 		return nil, fmt.Errorf("invalid linux kernel path: %w", err)
@@ -132,11 +132,11 @@ func WithEFIVariableStore(variableStore *EFIVariableStore) NewEFIBootLoaderOptio
 
 // NewEFIBootLoader creates a new EFI boot loader.
 //
-// This is only supported on macOS 13 and newer, ErrUnsupportedOSVersion will
+// This is only supported on macOS 13 and newer, error will
 // be returned on older versions.
 func NewEFIBootLoader(opts ...NewEFIBootLoaderOption) (*EFIBootLoader, error) {
-	if macosMajorVersionLessThan(13) {
-		return nil, ErrUnsupportedOSVersion
+	if err := macOSAvailable(13); err != nil {
+		return nil, err
 	}
 	bootLoader := &EFIBootLoader{
 		pointer: objc.NewPointer(
@@ -194,11 +194,11 @@ func WithCreatingEFIVariableStore() NewEFIVariableStoreOption {
 // NewEFIVariableStore Initialize the variable store. If no options are specified,
 // it initialises from the paths that exist.
 //
-// This is only supported on macOS 13 and newer, ErrUnsupportedOSVersion will
+// This is only supported on macOS 13 and newer, error will
 // be returned on older versions.
 func NewEFIVariableStore(path string, opts ...NewEFIVariableStoreOption) (*EFIVariableStore, error) {
-	if macosMajorVersionLessThan(13) {
-		return nil, ErrUnsupportedOSVersion
+	if err := macOSAvailable(13); err != nil {
+		return nil, err
 	}
 	variableStore := &EFIVariableStore{path: path}
 	for _, optFunc := range opts {

--- a/bootloader_arm64.go
+++ b/bootloader_arm64.go
@@ -26,11 +26,11 @@ var _ BootLoader = (*MacOSBootLoader)(nil)
 
 // NewMacOSBootLoader creates a new MacOSBootLoader struct.
 //
-// This is only supported on macOS 12 and newer, ErrUnsupportedOSVersion will
+// This is only supported on macOS 12 and newer, error will
 // be returned on older versions.
 func NewMacOSBootLoader() (*MacOSBootLoader, error) {
-	if macosMajorVersionLessThan(12) {
-		return nil, ErrUnsupportedOSVersion
+	if err := macOSAvailable(12); err != nil {
+		return nil, err
 	}
 
 	bootLoader := &MacOSBootLoader{

--- a/clipboard.go
+++ b/clipboard.go
@@ -28,11 +28,11 @@ var _ SerialPortAttachment = (*SpiceAgentPortAttachment)(nil)
 
 // NewSpiceAgentPortAttachment creates a new Spice agent port attachment.
 //
-// This is only supported on macOS 13 and newer, ErrUnsupportedOSVersion will
+// This is only supported on macOS 13 and newer, error will
 // be returned on older versions.
 func NewSpiceAgentPortAttachment() (*SpiceAgentPortAttachment, error) {
-	if macosMajorVersionLessThan(13) {
-		return nil, ErrUnsupportedOSVersion
+	if err := macOSAvailable(13); err != nil {
+		return nil, err
 	}
 	spiceAgent := &SpiceAgentPortAttachment{
 		pointer: objc.NewPointer(
@@ -60,8 +60,8 @@ func (s *SpiceAgentPortAttachment) SharesClipboard() bool { return s.enabledShar
 
 // SpiceAgentPortAttachmentName returns the Spice agent port name.
 func SpiceAgentPortAttachmentName() (string, error) {
-	if macosMajorVersionLessThan(13) {
-		return "", ErrUnsupportedOSVersion
+	if err := macOSAvailable(13); err != nil {
+		return "", err
 	}
 	cstring := (*char)(C.getSpiceAgentPortName())
 	return cstring.String(), nil

--- a/configuration.go
+++ b/configuration.go
@@ -49,11 +49,11 @@ type VirtualMachineConfiguration struct {
 //     The memory size must be a multiple of a 1 megabyte (1024 * 1024 bytes) between
 //     VZVirtualMachineConfiguration.minimumAllowedMemorySize and VZVirtualMachineConfiguration.maximumAllowedMemorySize.
 //
-// This is only supported on macOS 11 and newer, ErrUnsupportedOSVersion will
+// This is only supported on macOS 11 and newer, error will
 // be returned on older versions.
 func NewVirtualMachineConfiguration(bootLoader BootLoader, cpu uint, memorySize uint64) (*VirtualMachineConfiguration, error) {
-	if macosMajorVersionLessThan(11) {
-		return nil, ErrUnsupportedOSVersion
+	if err := macOSAvailable(11); err != nil {
+		return nil, err
 	}
 
 	config := &VirtualMachineConfiguration{
@@ -179,7 +179,7 @@ func (v *VirtualMachineConfiguration) SetStorageDevicesVirtualMachineConfigurati
 //
 // This is only supported on macOS 12 and newer. Older versions do nothing.
 func (v *VirtualMachineConfiguration) SetDirectorySharingDevicesVirtualMachineConfiguration(cs []DirectorySharingDeviceConfiguration) {
-	if macosMajorVersionLessThan(12) {
+	if err := macOSAvailable(12); err != nil {
 		return
 	}
 	ptrs := make([]objc.NSObject, len(cs))
@@ -194,7 +194,7 @@ func (v *VirtualMachineConfiguration) SetDirectorySharingDevicesVirtualMachineCo
 //
 // This is only supported on macOS 12 and newer. Older versions do nothing.
 func (v *VirtualMachineConfiguration) SetPlatformVirtualMachineConfiguration(c PlatformConfiguration) {
-	if macosMajorVersionLessThan(12) {
+	if err := macOSAvailable(12); err != nil {
 		return
 	}
 	C.setPlatformVZVirtualMachineConfiguration(objc.Ptr(v), objc.Ptr(c))
@@ -204,7 +204,7 @@ func (v *VirtualMachineConfiguration) SetPlatformVirtualMachineConfiguration(c P
 //
 // This is only supported on macOS 12 and newer. Older versions do nothing.
 func (v *VirtualMachineConfiguration) SetGraphicsDevicesVirtualMachineConfiguration(cs []GraphicsDeviceConfiguration) {
-	if macosMajorVersionLessThan(12) {
+	if err := macOSAvailable(12); err != nil {
 		return
 	}
 	ptrs := make([]objc.NSObject, len(cs))
@@ -219,7 +219,7 @@ func (v *VirtualMachineConfiguration) SetGraphicsDevicesVirtualMachineConfigurat
 //
 // This is only supported on macOS 12 and newer. Older versions do nothing.
 func (v *VirtualMachineConfiguration) SetPointingDevicesVirtualMachineConfiguration(cs []PointingDeviceConfiguration) {
-	if macosMajorVersionLessThan(12) {
+	if err := macOSAvailable(12); err != nil {
 		return
 	}
 	ptrs := make([]objc.NSObject, len(cs))
@@ -234,7 +234,7 @@ func (v *VirtualMachineConfiguration) SetPointingDevicesVirtualMachineConfigurat
 //
 // This is only supported on macOS 12 and newer. Older versions do nothing.
 func (v *VirtualMachineConfiguration) SetKeyboardsVirtualMachineConfiguration(cs []KeyboardConfiguration) {
-	if macosMajorVersionLessThan(12) {
+	if err := macOSAvailable(12); err != nil {
 		return
 	}
 	ptrs := make([]objc.NSObject, len(cs))
@@ -249,7 +249,7 @@ func (v *VirtualMachineConfiguration) SetKeyboardsVirtualMachineConfiguration(cs
 //
 // This is only supported on macOS 12 and newer. Older versions do nothing.
 func (v *VirtualMachineConfiguration) SetAudioDevicesVirtualMachineConfiguration(cs []AudioDeviceConfiguration) {
-	if macosMajorVersionLessThan(12) {
+	if err := macOSAvailable(12); err != nil {
 		return
 	}
 	ptrs := make([]objc.NSObject, len(cs))
@@ -264,7 +264,7 @@ func (v *VirtualMachineConfiguration) SetAudioDevicesVirtualMachineConfiguration
 //
 // This is only supported on macOS 13 and newer. Older versions do nothing.
 func (v *VirtualMachineConfiguration) SetConsoleDevicesVirtualMachineConfiguration(cs []ConsoleDeviceConfiguration) {
-	if macosMajorVersionLessThan(13) {
+	if err := macOSAvailable(13); err != nil {
 		return
 	}
 	ptrs := make([]objc.NSObject, len(cs))

--- a/console.go
+++ b/console.go
@@ -38,8 +38,8 @@ var _ ConsoleDeviceConfiguration = (*VirtioConsoleDeviceConfiguration)(nil)
 
 // NewVirtioConsoleDeviceConfiguration creates a new VirtioConsoleDeviceConfiguration.
 func NewVirtioConsoleDeviceConfiguration() (*VirtioConsoleDeviceConfiguration, error) {
-	if macosMajorVersionLessThan(13) {
-		return nil, ErrUnsupportedOSVersion
+	if err := macOSAvailable(13); err != nil {
+		return nil, err
 	}
 	config := &VirtioConsoleDeviceConfiguration{
 		pointer: objc.NewPointer(
@@ -142,11 +142,11 @@ func WithVirtioConsolePortConfigurationAttachment(attachment SerialPortAttachmen
 
 // NewVirtioConsolePortConfiguration creates a new VirtioConsolePortConfiguration.
 //
-// This is only supported on macOS 13 and newer, ErrUnsupportedOSVersion will
+// This is only supported on macOS 13 and newer, error will
 // be returned on older versions.
 func NewVirtioConsolePortConfiguration(opts ...NewVirtioConsolePortConfigurationOption) (*VirtioConsolePortConfiguration, error) {
-	if macosMajorVersionLessThan(13) {
-		return nil, ErrUnsupportedOSVersion
+	if err := macOSAvailable(13); err != nil {
+		return nil, err
 	}
 	vcpc := &VirtioConsolePortConfiguration{
 		pointer: objc.NewPointer(

--- a/debug.go
+++ b/debug.go
@@ -39,11 +39,11 @@ var _ DebugStubConfiguration = (*GDBDebugStubConfiguration)(nil)
 //
 // This API is not officially published and is subject to change without notice.
 //
-// This is only supported on macOS 11 and newer, ErrUnsupportedOSVersion will
+// This is only supported on macOS 11 and newer, error will
 // be returned on older versions.
 func NewGDBDebugStubConfiguration(port uint32) (*GDBDebugStubConfiguration, error) {
-	if macosMajorVersionLessThan(11) {
-		return nil, ErrUnsupportedOSVersion
+	if err := macOSAvailable(11); err != nil {
+		return nil, err
 	}
 
 	config := &GDBDebugStubConfiguration{

--- a/entropy.go
+++ b/entropy.go
@@ -23,11 +23,11 @@ type VirtioEntropyDeviceConfiguration struct {
 
 // NewVirtioEntropyDeviceConfiguration creates a new Virtio Entropy Device confiuration.
 //
-// This is only supported on macOS 11 and newer, ErrUnsupportedOSVersion will
+// This is only supported on macOS 11 and newer, error will
 // be returned on older versions.
 func NewVirtioEntropyDeviceConfiguration() (*VirtioEntropyDeviceConfiguration, error) {
-	if macosMajorVersionLessThan(11) {
-		return nil, ErrUnsupportedOSVersion
+	if err := macOSAvailable(11); err != nil {
+		return nil, err
 	}
 
 	config := &VirtioEntropyDeviceConfiguration{

--- a/example/gui-linux/go.mod
+++ b/example/gui-linux/go.mod
@@ -11,6 +11,7 @@ require (
 
 require (
 	github.com/mattn/go-isatty v0.0.14 // indirect
+	golang.org/x/mod v0.6.0 // indirect
 	golang.org/x/sys v0.1.0 // indirect
 	golang.org/x/term v0.0.0-20220526004731-065cf7ba2467 // indirect
 )

--- a/example/gui-linux/go.sum
+++ b/example/gui-linux/go.sum
@@ -3,6 +3,8 @@ github.com/Songmu/prompter v0.5.1/go.mod h1:CS3jEPD6h9IaLaG6afrl1orTgII9+uDWuw95
 github.com/mattn/go-isatty v0.0.14 h1:yVuAays6BHfxijgZPzw+3Zlu5yQgKGP2/hcQbHb7S9Y=
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 golang.org/x/crypto v0.1.0 h1:MDRAIl0xIo9Io2xV565hzXHw3zVseKrJKodhohM5CjU=
+golang.org/x/mod v0.6.0 h1:b9gGHsz9/HhJ3HF5DHQytPpuwocVTChQJK3AvoLRD5I=
+golang.org/x/mod v0.6.0/go.mod h1:4mET923SAdbXp2ki8ey+zGs1SLqsuM2Y0uvdZR/fUNI=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.1.0 h1:kunALQeHf1/185U1i0GOB/fy1IPRDDpuoOOqRReG57U=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/example/linux/go.sum
+++ b/example/linux/go.sum
@@ -6,6 +6,8 @@ golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5y
 golang.org/x/crypto v0.1.0 h1:MDRAIl0xIo9Io2xV565hzXHw3zVseKrJKodhohM5CjU=
 golang.org/x/crypto v0.1.0/go.mod h1:RecgLatLF4+eUMCP1PoPZQb+cVrJcOPbHkTkbkB9sbw=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
+golang.org/x/mod v0.6.0 h1:b9gGHsz9/HhJ3HF5DHQytPpuwocVTChQJK3AvoLRD5I=
+golang.org/x/mod v0.6.0/go.mod h1:4mET923SAdbXp2ki8ey+zGs1SLqsuM2Y0uvdZR/fUNI=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=

--- a/example/macOS/go.sum
+++ b/example/macOS/go.sum
@@ -4,6 +4,8 @@ golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5y
 golang.org/x/crypto v0.1.0 h1:MDRAIl0xIo9Io2xV565hzXHw3zVseKrJKodhohM5CjU=
 golang.org/x/crypto v0.1.0/go.mod h1:RecgLatLF4+eUMCP1PoPZQb+cVrJcOPbHkTkbkB9sbw=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
+golang.org/x/mod v0.6.0 h1:b9gGHsz9/HhJ3HF5DHQytPpuwocVTChQJK3AvoLRD5I=
+golang.org/x/mod v0.6.0/go.mod h1:4mET923SAdbXp2ki8ey+zGs1SLqsuM2Y0uvdZR/fUNI=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,9 @@ module github.com/Code-Hex/vz/v2
 
 go 1.17
 
-require golang.org/x/crypto v0.1.0
+require (
+	golang.org/x/crypto v0.1.0
+	golang.org/x/mod v0.6.0
+)
 
 require golang.org/x/sys v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5y
 golang.org/x/crypto v0.1.0 h1:MDRAIl0xIo9Io2xV565hzXHw3zVseKrJKodhohM5CjU=
 golang.org/x/crypto v0.1.0/go.mod h1:RecgLatLF4+eUMCP1PoPZQb+cVrJcOPbHkTkbkB9sbw=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
+golang.org/x/mod v0.6.0 h1:b9gGHsz9/HhJ3HF5DHQytPpuwocVTChQJK3AvoLRD5I=
+golang.org/x/mod v0.6.0/go.mod h1:4mET923SAdbXp2ki8ey+zGs1SLqsuM2Y0uvdZR/fUNI=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=

--- a/graphics.go
+++ b/graphics.go
@@ -40,11 +40,11 @@ var _ GraphicsDeviceConfiguration = (*VirtioGraphicsDeviceConfiguration)(nil)
 
 // NewVirtioGraphicsDeviceConfiguration creates a new Virtio graphics device.
 //
-// This is only supported on macOS 13 and newer, ErrUnsupportedOSVersion will
+// This is only supported on macOS 13 and newer, error will
 // be returned on older versions.
 func NewVirtioGraphicsDeviceConfiguration() (*VirtioGraphicsDeviceConfiguration, error) {
-	if macosMajorVersionLessThan(13) {
-		return nil, ErrUnsupportedOSVersion
+	if err := macOSAvailable(13); err != nil {
+		return nil, err
 	}
 	graphicsConfiguration := &VirtioGraphicsDeviceConfiguration{
 		pointer: objc.NewPointer(
@@ -78,11 +78,11 @@ type VirtioGraphicsScanoutConfiguration struct {
 
 // NewVirtioGraphicsScanoutConfiguration creates a Virtio graphics device with the specified dimensions.
 //
-// This is only supported on macOS 12 and newer, ErrUnsupportedOSVersion will
+// This is only supported on macOS 12 and newer, error will
 // be returned on older versions.
 func NewVirtioGraphicsScanoutConfiguration(widthInPixels int64, heightInPixels int64) (*VirtioGraphicsScanoutConfiguration, error) {
-	if macosMajorVersionLessThan(12) {
-		return nil, ErrUnsupportedOSVersion
+	if err := macOSAvailable(12); err != nil {
+		return nil, err
 	}
 
 	graphicsScanoutConfiguration := &VirtioGraphicsScanoutConfiguration{

--- a/graphics_arm64.go
+++ b/graphics_arm64.go
@@ -26,11 +26,11 @@ var _ GraphicsDeviceConfiguration = (*MacGraphicsDeviceConfiguration)(nil)
 
 // NewMacGraphicsDeviceConfiguration creates a new MacGraphicsDeviceConfiguration.
 //
-// This is only supported on macOS 12 and newer, ErrUnsupportedOSVersion will
+// This is only supported on macOS 12 and newer, error will
 // be returned on older versions.
 func NewMacGraphicsDeviceConfiguration() (*MacGraphicsDeviceConfiguration, error) {
-	if macosMajorVersionLessThan(12) {
-		return nil, ErrUnsupportedOSVersion
+	if err := macOSAvailable(12); err != nil {
+		return nil, err
 	}
 
 	graphicsConfiguration := &MacGraphicsDeviceConfiguration{
@@ -63,11 +63,11 @@ type MacGraphicsDisplayConfiguration struct {
 //
 // Creates a display configuration with the specified pixel dimensions and pixel density.
 //
-// This is only supported on macOS 12 and newer, ErrUnsupportedOSVersion will
+// This is only supported on macOS 12 and newer, error will
 // be returned on older versions.
 func NewMacGraphicsDisplayConfiguration(widthInPixels int64, heightInPixels int64, pixelsPerInch int64) (*MacGraphicsDisplayConfiguration, error) {
-	if macosMajorVersionLessThan(12) {
-		return nil, ErrUnsupportedOSVersion
+	if err := macOSAvailable(12); err != nil {
+		return nil, err
 	}
 
 	graphicsDisplayConfiguration := &MacGraphicsDisplayConfiguration{

--- a/keyboard.go
+++ b/keyboard.go
@@ -34,11 +34,11 @@ var _ KeyboardConfiguration = (*USBKeyboardConfiguration)(nil)
 
 // NewUSBKeyboardConfiguration creates a new USB keyboard configuration.
 //
-// This is only supported on macOS 12 and newer, ErrUnsupportedOSVersion will
+// This is only supported on macOS 12 and newer, error will
 // be returned on older versions.
 func NewUSBKeyboardConfiguration() (*USBKeyboardConfiguration, error) {
-	if macosMajorVersionLessThan(12) {
-		return nil, ErrUnsupportedOSVersion
+	if err := macOSAvailable(12); err != nil {
+		return nil, err
 	}
 	config := &USBKeyboardConfiguration{
 		pointer: objc.NewPointer(C.newVZUSBKeyboardConfiguration()),

--- a/memory_balloon.go
+++ b/memory_balloon.go
@@ -36,11 +36,11 @@ type VirtioTraditionalMemoryBalloonDeviceConfiguration struct {
 
 // NewVirtioTraditionalMemoryBalloonDeviceConfiguration creates a new VirtioTraditionalMemoryBalloonDeviceConfiguration.
 //
-// This is only supported on macOS 11 and newer, ErrUnsupportedOSVersion will
+// This is only supported on macOS 11 and newer, error will
 // be returned on older versions.
 func NewVirtioTraditionalMemoryBalloonDeviceConfiguration() (*VirtioTraditionalMemoryBalloonDeviceConfiguration, error) {
-	if macosMajorVersionLessThan(11) {
-		return nil, ErrUnsupportedOSVersion
+	if err := macOSAvailable(11); err != nil {
+		return nil, err
 	}
 
 	config := &VirtioTraditionalMemoryBalloonDeviceConfiguration{

--- a/network.go
+++ b/network.go
@@ -55,11 +55,11 @@ var _ NetworkDeviceAttachment = (*NATNetworkDeviceAttachment)(nil)
 
 // NewNATNetworkDeviceAttachment creates a new NATNetworkDeviceAttachment.
 //
-// This is only supported on macOS 11 and newer, ErrUnsupportedOSVersion will
+// This is only supported on macOS 11 and newer, error will
 // be returned on older versions.
 func NewNATNetworkDeviceAttachment() (*NATNetworkDeviceAttachment, error) {
-	if macosMajorVersionLessThan(11) {
-		return nil, ErrUnsupportedOSVersion
+	if err := macOSAvailable(11); err != nil {
+		return nil, err
 	}
 
 	attachment := &NATNetworkDeviceAttachment{
@@ -91,11 +91,11 @@ var _ NetworkDeviceAttachment = (*BridgedNetworkDeviceAttachment)(nil)
 
 // NewBridgedNetworkDeviceAttachment creates a new BridgedNetworkDeviceAttachment with networkInterface.
 //
-// This is only supported on macOS 11 and newer, ErrUnsupportedOSVersion will
+// This is only supported on macOS 11 and newer, error will
 // be returned on older versions.
 func NewBridgedNetworkDeviceAttachment(networkInterface BridgedNetwork) (*BridgedNetworkDeviceAttachment, error) {
-	if macosMajorVersionLessThan(11) {
-		return nil, ErrUnsupportedOSVersion
+	if err := macOSAvailable(11); err != nil {
+		return nil, err
 	}
 
 	attachment := &BridgedNetworkDeviceAttachment{
@@ -130,11 +130,11 @@ var _ NetworkDeviceAttachment = (*FileHandleNetworkDeviceAttachment)(nil)
 //
 // file parameter is holding a connected datagram socket.
 //
-// This is only supported on macOS 11 and newer, ErrUnsupportedOSVersion will
+// This is only supported on macOS 11 and newer, error will
 // be returned on older versions.
 func NewFileHandleNetworkDeviceAttachment(file *os.File) (*FileHandleNetworkDeviceAttachment, error) {
-	if macosMajorVersionLessThan(11) {
-		return nil, ErrUnsupportedOSVersion
+	if err := macOSAvailable(11); err != nil {
+		return nil, err
 	}
 	err := validateDatagramSocket(int(file.Fd()))
 	if err != nil {
@@ -189,11 +189,11 @@ func isAvailableDatagram(fd int) bool {
 // the value of SO_RCVBUF to be at least double the value of SO_SNDBUF, and for optimal performance, the
 // recommended value of SO_RCVBUF is four times the value of SO_SNDBUF.
 //
-// This is only supported on macOS 13 and newer, ErrUnsupportedOSVersion will
+// This is only supported on macOS 13 and newer, error will
 // be returned on older versions.
 func (f *FileHandleNetworkDeviceAttachment) SetMaximumTransmissionUnit(mtu int) error {
-	if macosMajorVersionLessThan(13) {
-		return ErrUnsupportedOSVersion
+	if err := macOSAvailable(13); err != nil {
+		return err
 	}
 	C.setMaximumTransmissionUnitVZFileHandleNetworkDeviceAttachment(
 		objc.Ptr(f),
@@ -235,11 +235,11 @@ type VirtioNetworkDeviceConfiguration struct {
 
 // NewVirtioNetworkDeviceConfiguration creates a new VirtioNetworkDeviceConfiguration with NetworkDeviceAttachment.
 //
-// This is only supported on macOS 11 and newer, ErrUnsupportedOSVersion will
+// This is only supported on macOS 11 and newer, error will
 // be returned on older versions.
 func NewVirtioNetworkDeviceConfiguration(attachment NetworkDeviceAttachment) (*VirtioNetworkDeviceConfiguration, error) {
-	if macosMajorVersionLessThan(11) {
-		return nil, ErrUnsupportedOSVersion
+	if err := macOSAvailable(11); err != nil {
+		return nil, err
 	}
 
 	config := newVirtioNetworkDeviceConfiguration(
@@ -271,11 +271,11 @@ type MACAddress struct {
 
 // NewMACAddress creates a new MACAddress with net.HardwareAddr (MAC address).
 //
-// This is only supported on macOS 11 and newer, ErrUnsupportedOSVersion will
+// This is only supported on macOS 11 and newer, error will
 // be returned on older versions.
 func NewMACAddress(macAddr net.HardwareAddr) (*MACAddress, error) {
-	if macosMajorVersionLessThan(11) {
-		return nil, ErrUnsupportedOSVersion
+	if err := macOSAvailable(11); err != nil {
+		return nil, err
 	}
 
 	macAddrChar := charWithGoString(macAddr.String())
@@ -293,11 +293,11 @@ func NewMACAddress(macAddr net.HardwareAddr) (*MACAddress, error) {
 
 // NewRandomLocallyAdministeredMACAddress creates a valid, random, unicast, locally administered address.
 //
-// This is only supported on macOS 11 and newer, ErrUnsupportedOSVersion will
+// This is only supported on macOS 11 and newer, error will
 // be returned on older versions.
 func NewRandomLocallyAdministeredMACAddress() (*MACAddress, error) {
-	if macosMajorVersionLessThan(11) {
-		return nil, ErrUnsupportedOSVersion
+	if err := macOSAvailable(11); err != nil {
+		return nil, err
 	}
 
 	ma := &MACAddress{

--- a/network_test.go
+++ b/network_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestFileHandleNetworkDeviceAttachmentMTU(t *testing.T) {
-	if vz.MacosMajorVersionLessThan(13) {
+	if vz.Available(13) {
 		t.Skip("FileHandleNetworkDeviceAttachment.SetMaximumTransmissionUnit is supported from macOS 13")
 	}
 

--- a/osversion_arm64_test.go
+++ b/osversion_arm64_test.go
@@ -11,13 +11,13 @@ import (
 )
 
 func TestAvailableVersionArm64(t *testing.T) {
-	majorVersionOnce = &nopDoer{}
+	majorMinorVersionOnce = &nopDoer{}
 	defer func() {
-		majorVersion = 0
-		majorVersionOnce = &sync.Once{}
+		majorMinorVersion = 0
+		majorMinorVersionOnce = &sync.Once{}
 	}()
 	t.Run("macOS 12", func(t *testing.T) {
-		majorVersion = 11
+		majorMinorVersion = 11
 		cases := map[string]func() error{
 			"NewMacOSBootLoader": func() error {
 				_, err := NewMacOSBootLoader()

--- a/osversion_test.go
+++ b/osversion_test.go
@@ -14,14 +14,14 @@ type nopDoer struct{}
 func (*nopDoer) Do(func()) {}
 
 func TestAvailableVersion(t *testing.T) {
-	majorVersionOnce = &nopDoer{}
+	majorMinorVersionOnce = &nopDoer{}
 	defer func() {
-		majorVersion = 0
-		majorVersionOnce = &sync.Once{}
+		majorMinorVersion = 0
+		majorMinorVersionOnce = &sync.Once{}
 	}()
 
 	t.Run("macOS 11", func(t *testing.T) {
-		majorVersion = 10
+		majorMinorVersion = 10
 		cases := map[string]func() error{
 			"NewLinuxBootLoader": func() error {
 				_, err := NewLinuxBootLoader("")
@@ -105,7 +105,7 @@ func TestAvailableVersion(t *testing.T) {
 	})
 
 	t.Run("macOS 12", func(t *testing.T) {
-		majorVersion = 11
+		majorMinorVersion = 11
 		cases := map[string]func() error{
 			"NewVirtioSoundDeviceConfiguration": func() error {
 				_, err := NewVirtioSoundDeviceConfiguration()
@@ -222,6 +222,11 @@ func Test_fetchMajorMinorVersion(t *testing.T) {
 }
 
 func Test_macOSBuildTargetAvailable(t *testing.T) {
+	maxAllowedVersionOnce = &nopDoer{}
+	defer func() {
+		maxAllowedVersionOnce = &sync.Once{}
+	}()
+
 	cases := []struct {
 		// version is specified only 11, 12, 12.3, 13
 		version           float64
@@ -308,11 +313,9 @@ func Test_macOSBuildTargetAvailable(t *testing.T) {
 			tc.version,
 		)
 		t.Run(name, func(t *testing.T) {
-			_maxAllowedVersion := maxAllowedVersion
-			defer func() { maxAllowedVersion = _maxAllowedVersion }()
-			maxAllowedVersion = func() int {
-				return tc.maxAllowedVersion
-			}
+			tmp := maxAllowedVersion
+			defer func() { maxAllowedVersion = tmp }()
+			maxAllowedVersion = tc.maxAllowedVersion
 
 			err := macOSBuildTargetAvailable(tc.version)
 			if (err != nil) != tc.wantErr {

--- a/osversion_test.go
+++ b/osversion_test.go
@@ -2,6 +2,8 @@ package vz
 
 import (
 	"errors"
+	"fmt"
+	"strings"
 	"sync"
 	"syscall"
 	"testing"
@@ -161,7 +163,7 @@ func TestAvailableVersion(t *testing.T) {
 	})
 }
 
-func Test_fetchMajorVersion(t *testing.T) {
+func Test_fetchMajorMinorVersion(t *testing.T) {
 	tests := []struct {
 		name    string
 		sysctl  func(string) (string, error)
@@ -185,6 +187,14 @@ func Test_fetchMajorVersion(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "valid 12.3.1",
+			sysctl: func(s string) (string, error) {
+				return "12.3.1", nil
+			},
+			want:    12.3,
+			wantErr: false,
+		},
+		{
 			name: "invalid unknown",
 			sysctl: func(s string) (string, error) {
 				return "unknown", nil
@@ -200,12 +210,122 @@ func Test_fetchMajorVersion(t *testing.T) {
 				sysctl = syscall.Sysctl
 			}()
 
-			version, err := fetchMajorVersion()
+			version, err := fetchMajorMinorVersion()
 			if (err != nil) != tt.wantErr {
-				t.Errorf("fetchMajorVersion() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("fetchMajorMinorVersion() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			if version != tt.want {
 				t.Errorf("want version %.3f but got %.3f", tt.want, version)
+			}
+		})
+	}
+}
+
+func Test_macOSBuildTargetAvailable(t *testing.T) {
+	cases := []struct {
+		// version is specified only 11, 12, 12.3, 13
+		version           float64
+		maxAllowedVersion int
+		wantErr           bool
+		wantErrMsg        string
+	}{
+		{
+			version:           11,
+			maxAllowedVersion: 0, // undefined case
+			wantErr:           true,
+			wantErrMsg:        "undefined __MAC_OS_X_VERSION_MAX_ALLOWED",
+		},
+		{
+			version:           11,
+			maxAllowedVersion: 100000,
+			wantErr:           true,
+			wantErrMsg:        "for 11.0",
+		},
+		{
+			version:           11,
+			maxAllowedVersion: 110000,
+		},
+		{
+			version:           12,
+			maxAllowedVersion: 110000,
+			wantErr:           true,
+			wantErrMsg:        "for 12.0",
+		},
+		{
+			version:           12,
+			maxAllowedVersion: 120000,
+		},
+		{
+			version:           12,
+			maxAllowedVersion: 120100, // __MAC_12_1
+		},
+		{
+			version:           12,
+			maxAllowedVersion: 120200, // __MAC_12_2
+		},
+		{
+			version:           12,
+			maxAllowedVersion: 120300, // __MAC_12_3
+		},
+		{
+			version:           12,
+			maxAllowedVersion: 130000, // __MAC_13_0
+		},
+		{
+			version:           12.3,
+			maxAllowedVersion: 120000,
+			wantErr:           true,
+			wantErrMsg:        "for 12.3",
+		},
+		{
+			version:           12.3,
+			maxAllowedVersion: 120300, // __MAC_12_3
+		},
+		{
+			version:           12.3,
+			maxAllowedVersion: 130000, // __MAC_13_0
+		},
+		{
+			version:           13,
+			maxAllowedVersion: 120300,
+			wantErr:           true,
+			wantErrMsg:        "for 13.0",
+		},
+		{
+			version:           13,
+			maxAllowedVersion: 130000, // __MAC_13_0
+		},
+	}
+	for _, tc := range cases {
+		prefix := "valid"
+		if tc.wantErr {
+			prefix = "invalid"
+		}
+		name := fmt.Sprintf(
+			"%s maxAllowedVersion is %d and API target %.1f",
+			prefix,
+			tc.maxAllowedVersion,
+			tc.version,
+		)
+		t.Run(name, func(t *testing.T) {
+			_maxAllowedVersion := maxAllowedVersion
+			defer func() { maxAllowedVersion = _maxAllowedVersion }()
+			maxAllowedVersion = func() int {
+				return tc.maxAllowedVersion
+			}
+
+			err := macOSBuildTargetAvailable(tc.version)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("macOSBuildTargetAvailable(%.1f) error = %v, wantErr %v", tc.version, err, tc.wantErr)
+			}
+			if tc.wantErr {
+				got := err.Error()
+				if !strings.Contains(got, tc.wantErrMsg) {
+					t.Errorf("want msg %q but got %q", tc.wantErrMsg, got)
+				}
+				if !errors.Is(err, ErrBuildTargetOSVersion) {
+					t.Errorf("unexpected unwrap error: %v", err)
+				}
 			}
 		})
 	}

--- a/platform.go
+++ b/platform.go
@@ -44,11 +44,11 @@ var _ PlatformConfiguration = (*GenericPlatformConfiguration)(nil)
 
 // NewGenericPlatformConfiguration creates a new generic platform configuration.
 //
-// This is only supported on macOS 12 and newer, ErrUnsupportedOSVersion will
+// This is only supported on macOS 12 and newer, error will
 // be returned on older versions.
 func NewGenericPlatformConfiguration(opts ...GenericPlatformConfigurationOption) (*GenericPlatformConfiguration, error) {
-	if macosMajorVersionLessThan(12) {
-		return nil, ErrUnsupportedOSVersion
+	if err := macOSAvailable(12); err != nil {
+		return nil, err
 	}
 
 	platformConfig := &GenericPlatformConfiguration{
@@ -77,7 +77,7 @@ type GenericMachineIdentifier struct {
 
 // NewGenericMachineIdentifierWithDataPath initialize a new machine identifier described by the specified pathname.
 //
-// This is only supported on macOS 13 and newer, ErrUnsupportedOSVersion will
+// This is only supported on macOS 13 and newer, error will
 // be returned on older versions.
 func NewGenericMachineIdentifierWithDataPath(pathname string) (*GenericMachineIdentifier, error) {
 	b, err := os.ReadFile(pathname)
@@ -89,11 +89,11 @@ func NewGenericMachineIdentifierWithDataPath(pathname string) (*GenericMachineId
 
 // NewGenericMachineIdentifierWithData initialize a new machine identifier described by the specified data representation.
 //
-// This is only supported on macOS 13 and newer, ErrUnsupportedOSVersion will
+// This is only supported on macOS 13 and newer, error will
 // be returned on older versions.
 func NewGenericMachineIdentifierWithData(b []byte) (*GenericMachineIdentifier, error) {
-	if macosMajorVersionLessThan(13) {
-		return nil, ErrUnsupportedOSVersion
+	if err := macOSAvailable(13); err != nil {
+		return nil, err
 	}
 
 	ptr := C.newVZGenericMachineIdentifierWithBytes(
@@ -112,11 +112,11 @@ func NewGenericMachineIdentifierWithData(b []byte) (*GenericMachineIdentifier, e
 // DataRepresentation method.
 // The identifier can then be recreated with NewGenericMachineIdentifierWithData function from the binary representation.
 //
-// This is only supported on macOS 13 and newer, ErrUnsupportedOSVersion will
+// This is only supported on macOS 13 and newer, error will
 // be returned on older versions.
 func NewGenericMachineIdentifier() (*GenericMachineIdentifier, error) {
-	if macosMajorVersionLessThan(13) {
-		return nil, ErrUnsupportedOSVersion
+	if err := macOSAvailable(13); err != nil {
+		return nil, err
 	}
 	return newGenericMachineIdentifier(C.newVZGenericMachineIdentifier()), nil
 }
@@ -140,12 +140,12 @@ type GenericPlatformConfigurationOption func(*GenericPlatformConfiguration) erro
 
 // WithGenericMachineIdentifier is an option to create a new GenericPlatformConfiguration.
 //
-// This is only supported on macOS 13 and newer, ErrUnsupportedOSVersion will
+// This is only supported on macOS 13 and newer, error will
 // be returned on older versions.
 func WithGenericMachineIdentifier(m *GenericMachineIdentifier) GenericPlatformConfigurationOption {
 	return func(mpc *GenericPlatformConfiguration) error {
-		if macosMajorVersionLessThan(13) {
-			return ErrUnsupportedOSVersion
+		if err := macOSAvailable(13); err != nil {
+			return err
 		}
 		mpc.machineIdentifier = m
 		C.setMachineIdentifierVZGenericPlatformConfiguration(objc.Ptr(mpc), objc.Ptr(m))

--- a/platform_arm64.go
+++ b/platform_arm64.go
@@ -70,11 +70,11 @@ func WithAuxiliaryStorage(m *MacAuxiliaryStorage) MacPlatformConfigurationOption
 
 // NewMacPlatformConfiguration creates a new MacPlatformConfiguration. see also it's document.
 //
-// This is only supported on macOS 12 and newer, ErrUnsupportedOSVersion will
+// This is only supported on macOS 12 and newer, error will
 // be returned on older versions.
 func NewMacPlatformConfiguration(opts ...MacPlatformConfigurationOption) (*MacPlatformConfiguration, error) {
-	if macosMajorVersionLessThan(12) {
-		return nil, ErrUnsupportedOSVersion
+	if err := macOSAvailable(12); err != nil {
+		return nil, err
 	}
 
 	platformConfig := &MacPlatformConfiguration{

--- a/pointing_device.go
+++ b/pointing_device.go
@@ -35,11 +35,11 @@ var _ PointingDeviceConfiguration = (*USBScreenCoordinatePointingDeviceConfigura
 
 // NewUSBScreenCoordinatePointingDeviceConfiguration creates a new USBScreenCoordinatePointingDeviceConfiguration.
 //
-// This is only supported on macOS 12 and newer, ErrUnsupportedOSVersion will
+// This is only supported on macOS 12 and newer, error will
 // be returned on older versions.
 func NewUSBScreenCoordinatePointingDeviceConfiguration() (*USBScreenCoordinatePointingDeviceConfiguration, error) {
-	if macosMajorVersionLessThan(12) {
-		return nil, ErrUnsupportedOSVersion
+	if err := macOSAvailable(12); err != nil {
+		return nil, err
 	}
 	config := &USBScreenCoordinatePointingDeviceConfiguration{
 		pointer: objc.NewPointer(

--- a/pointing_device_arm64.go
+++ b/pointing_device_arm64.go
@@ -35,11 +35,11 @@ var _ PointingDeviceConfiguration = (*MacTrackpadConfiguration)(nil)
 
 // NewMacTrackpadConfiguration creates a new MacTrackpadConfiguration.
 //
-// This is only supported on macOS 13 and newer, ErrUnsupportedOSVersion will
+// This is only supported on macOS 13 and newer, error will
 // be returned on older versions.
 func NewMacTrackpadConfiguration() (*MacTrackpadConfiguration, error) {
-	if macosMajorVersionLessThan(13) {
-		return nil, ErrUnsupportedOSVersion
+	if err := macOSAvailable(13); err != nil {
+		return nil, err
 	}
 	config := &MacTrackpadConfiguration{
 		pointer: objc.NewPointer(

--- a/serial_console.go
+++ b/serial_console.go
@@ -43,11 +43,11 @@ type FileHandleSerialPortAttachment struct {
 // read parameter is an *os.File for reading from the file.
 // write parameter is an *os.File for writing to the file.
 //
-// This is only supported on macOS 11 and newer, ErrUnsupportedOSVersion will
+// This is only supported on macOS 11 and newer, error will
 // be returned on older versions.
 func NewFileHandleSerialPortAttachment(read, write *os.File) (*FileHandleSerialPortAttachment, error) {
-	if macosMajorVersionLessThan(11) {
-		return nil, ErrUnsupportedOSVersion
+	if err := macOSAvailable(11); err != nil {
+		return nil, err
 	}
 
 	attachment := &FileHandleSerialPortAttachment{
@@ -84,11 +84,11 @@ type FileSerialPortAttachment struct {
 //   - shouldAppend True if the file should be opened in append mode, false otherwise.
 //     When a file is opened in append mode, writing to that file will append to the end of it.
 //
-// This is only supported on macOS 11 and newer, ErrUnsupportedOSVersion will
+// This is only supported on macOS 11 and newer, error will
 // be returned on older versions.
 func NewFileSerialPortAttachment(path string, shouldAppend bool) (*FileSerialPortAttachment, error) {
-	if macosMajorVersionLessThan(11) {
-		return nil, ErrUnsupportedOSVersion
+	if err := macOSAvailable(11); err != nil {
+		return nil, err
 	}
 
 	cpath := charWithGoString(path)
@@ -124,11 +124,11 @@ type VirtioConsoleDeviceSerialPortConfiguration struct {
 
 // NewVirtioConsoleDeviceSerialPortConfiguration creates a new NewVirtioConsoleDeviceSerialPortConfiguration.
 //
-// This is only supported on macOS 11 and newer, ErrUnsupportedOSVersion will
+// This is only supported on macOS 11 and newer, error will
 // be returned on older versions.
 func NewVirtioConsoleDeviceSerialPortConfiguration(attachment SerialPortAttachment) (*VirtioConsoleDeviceSerialPortConfiguration, error) {
-	if macosMajorVersionLessThan(11) {
-		return nil, ErrUnsupportedOSVersion
+	if err := macOSAvailable(11); err != nil {
+		return nil, err
 	}
 
 	config := &VirtioConsoleDeviceSerialPortConfiguration{

--- a/shared_directory.go
+++ b/shared_directory.go
@@ -38,11 +38,11 @@ type VirtioFileSystemDeviceConfiguration struct {
 
 // NewVirtioFileSystemDeviceConfiguration create a new VirtioFileSystemDeviceConfiguration.
 //
-// This is only supported on macOS 12 and newer, ErrUnsupportedOSVersion will
+// This is only supported on macOS 12 and newer, error will
 // be returned on older versions.
 func NewVirtioFileSystemDeviceConfiguration(tag string) (*VirtioFileSystemDeviceConfiguration, error) {
-	if macosMajorVersionLessThan(12) {
-		return nil, ErrUnsupportedOSVersion
+	if err := macOSAvailable(12); err != nil {
+		return nil, err
 	}
 	tagChar := charWithGoString(tag)
 	defer tagChar.Free()
@@ -74,11 +74,11 @@ type SharedDirectory struct {
 
 // NewSharedDirectory creates a new shared directory.
 //
-// This is only supported on macOS 12 and newer, ErrUnsupportedOSVersion will
+// This is only supported on macOS 12 and newer, error will
 // be returned on older versions.
 func NewSharedDirectory(dirPath string, readOnly bool) (*SharedDirectory, error) {
-	if macosMajorVersionLessThan(12) {
-		return nil, ErrUnsupportedOSVersion
+	if err := macOSAvailable(12); err != nil {
+		return nil, err
 	}
 	if _, err := os.Stat(dirPath); err != nil {
 		return nil, err
@@ -119,11 +119,11 @@ type SingleDirectoryShare struct {
 
 // NewSingleDirectoryShare creates a new single directory share.
 //
-// This is only supported on macOS 12 and newer, ErrUnsupportedOSVersion will
+// This is only supported on macOS 12 and newer, error will
 // be returned on older versions.
 func NewSingleDirectoryShare(share *SharedDirectory) (*SingleDirectoryShare, error) {
-	if macosMajorVersionLessThan(12) {
-		return nil, ErrUnsupportedOSVersion
+	if err := macOSAvailable(12); err != nil {
+		return nil, err
 	}
 	config := &SingleDirectoryShare{
 		pointer: objc.NewPointer(
@@ -147,11 +147,11 @@ var _ DirectoryShare = (*MultipleDirectoryShare)(nil)
 
 // NewMultipleDirectoryShare creates a new multiple directories share.
 //
-// This is only supported on macOS 12 and newer, ErrUnsupportedOSVersion will
+// This is only supported on macOS 12 and newer, error will
 // be returned on older versions.
 func NewMultipleDirectoryShare(shares map[string]*SharedDirectory) (*MultipleDirectoryShare, error) {
-	if macosMajorVersionLessThan(12) {
-		return nil, ErrUnsupportedOSVersion
+	if err := macOSAvailable(12); err != nil {
+		return nil, err
 	}
 	directories := make(map[string]objc.NSObject, len(shares))
 	for k, v := range shares {
@@ -174,11 +174,10 @@ func NewMultipleDirectoryShare(shares map[string]*SharedDirectory) (*MultipleDir
 // MacOSGuestAutomountTag returns the macOS automount tag.
 //
 // A device configured with this tag will be automatically mounted in a macOS guest.
-// This is only supported on macOS 13 and newer, ErrUnsupportedOSVersion will
-// be returned on older versions.
+// This is only supported on macOS 13 and newer, error will be returned on older versions.
 func MacOSGuestAutomountTag() (string, error) {
-	if macosMajorVersionLessThan(13) {
-		return "", ErrUnsupportedOSVersion
+	if err := macOSAvailable(13); err != nil {
+		return "", err
 	}
 	cstring := (*char)(C.getMacOSGuestAutomountTag())
 	return cstring.String(), nil

--- a/shared_directory_arm64.go
+++ b/shared_directory_arm64.go
@@ -59,11 +59,11 @@ var _ DirectoryShare = (*LinuxRosettaDirectoryShare)(nil)
 // NewLinuxRosettaDirectoryShare creates a new Rosetta directory share if Rosetta support
 // for Linux binaries is installed.
 //
-// This is only supported on macOS 13 and newer, ErrUnsupportedOSVersion will
+// This is only supported on macOS 13 and newer, error will
 // be returned on older versions.
 func NewLinuxRosettaDirectoryShare() (*LinuxRosettaDirectoryShare, error) {
-	if macosMajorVersionLessThan(13) {
-		return nil, ErrUnsupportedOSVersion
+	if err := macOSAvailable(13); err != nil {
+		return nil, err
 	}
 	nserrPtr := newNSErrorAsNil()
 	ds := &LinuxRosettaDirectoryShare{
@@ -83,11 +83,11 @@ func NewLinuxRosettaDirectoryShare() (*LinuxRosettaDirectoryShare, error) {
 // LinuxRosettaDirectoryShareInstallRosetta download and install Rosetta support
 // for Linux binaries if necessary.
 //
-// This is only supported on macOS 13 and newer, ErrUnsupportedOSVersion will
+// This is only supported on macOS 13 and newer, error will
 // be returned on older versions.
 func LinuxRosettaDirectoryShareInstallRosetta() error {
-	if macosMajorVersionLessThan(13) {
-		return ErrUnsupportedOSVersion
+	if err := macOSAvailable(13); err != nil {
+		return err
 	}
 	errCh := make(chan error, 1)
 	cgoHandler := cgo.NewHandle(func(err error) {
@@ -103,7 +103,7 @@ func LinuxRosettaDirectoryShareInstallRosetta() error {
 // This is only supported on macOS 13 and newer, LinuxRosettaAvailabilityNotSupported will
 // be returned on older versions.
 func LinuxRosettaDirectoryShareAvailability() LinuxRosettaAvailability {
-	if macosMajorVersionLessThan(13) {
+	if err := macOSAvailable(13); err != nil {
 		return LinuxRosettaAvailabilityNotSupported
 	}
 	return LinuxRosettaAvailability(C.availabilityVZLinuxRosettaDirectoryShare())

--- a/shared_directory_test.go
+++ b/shared_directory_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestVirtioFileSystemDeviceConfigurationTag(t *testing.T) {
-	if vz.MacosMajorVersionLessThan(12) {
+	if vz.Available(12) {
 		t.Skip("VirtioFileSystemDeviceConfiguration is supported from macOS 12")
 	}
 
@@ -32,7 +32,7 @@ func TestVirtioFileSystemDeviceConfigurationTag(t *testing.T) {
 }
 
 func TestSingleDirectoryShare(t *testing.T) {
-	if vz.MacosMajorVersionLessThan(12) {
+	if vz.Available(12) {
 		t.Skip("SingleDirectoryShare is supported from macOS 12")
 	}
 
@@ -146,7 +146,7 @@ func TestSingleDirectoryShare(t *testing.T) {
 }
 
 func TestMultipleDirectoryShare(t *testing.T) {
-	if vz.MacosMajorVersionLessThan(12) {
+	if vz.Available(12) {
 		t.Skip("MultipleDirectoryShare is supported from macOS 12")
 	}
 

--- a/socket.go
+++ b/socket.go
@@ -45,11 +45,11 @@ type VirtioSocketDeviceConfiguration struct {
 
 // NewVirtioSocketDeviceConfiguration creates a new VirtioSocketDeviceConfiguration.
 //
-// This is only supported on macOS 11 and newer, ErrUnsupportedOSVersion will
+// This is only supported on macOS 11 and newer, error will
 // be returned on older versions.
 func NewVirtioSocketDeviceConfiguration() (*VirtioSocketDeviceConfiguration, error) {
-	if macosMajorVersionLessThan(11) {
-		return nil, ErrUnsupportedOSVersion
+	if err := macOSAvailable(11); err != nil {
+		return nil, err
 	}
 
 	config := newVirtioSocketDeviceConfiguration(C.newVZVirtioSocketDeviceConfiguration())
@@ -88,11 +88,11 @@ func newVirtioSocketDevice(ptr, dispatchQueue unsafe.Pointer) *VirtioSocketDevic
 //
 // Be sure to close the listener by calling `VirtioSocketListener.Close` after used this one.
 //
-// This is only supported on macOS 11 and newer, ErrUnsupportedOSVersion will
+// This is only supported on macOS 11 and newer, error will
 // be returned on older versions.
 func (v *VirtioSocketDevice) Listen(port uint32) (*VirtioSocketListener, error) {
-	if macosMajorVersionLessThan(11) {
-		return nil, ErrUnsupportedOSVersion
+	if err := macOSAvailable(11); err != nil {
+		return nil, err
 	}
 
 	ch := make(chan connResults, 1) // should I increase more caps?

--- a/storage.go
+++ b/storage.go
@@ -47,11 +47,11 @@ type DiskImageStorageDeviceAttachment struct {
 // - diskPath is local file URL to the disk image in RAW format.
 // - readOnly if YES, the device attachment is read-only, otherwise the device can write data to the disk image.
 //
-// This is only supported on macOS 11 and newer, ErrUnsupportedOSVersion will
+// This is only supported on macOS 11 and newer, error will
 // be returned on older versions.
 func NewDiskImageStorageDeviceAttachment(diskPath string, readOnly bool) (*DiskImageStorageDeviceAttachment, error) {
-	if macosMajorVersionLessThan(11) {
-		return nil, ErrUnsupportedOSVersion
+	if err := macOSAvailable(11); err != nil {
+		return nil, err
 	}
 	if _, err := os.Stat(diskPath); err != nil {
 		return nil, err
@@ -110,11 +110,11 @@ type VirtioBlockDeviceConfiguration struct {
 //
 // - attachment The storage device attachment. This defines how the virtualized device operates on the host side.
 //
-// This is only supported on macOS 11 and newer, ErrUnsupportedOSVersion will
+// This is only supported on macOS 11 and newer, error will
 // be returned on older versions.
 func NewVirtioBlockDeviceConfiguration(attachment StorageDeviceAttachment) (*VirtioBlockDeviceConfiguration, error) {
-	if macosMajorVersionLessThan(11) {
-		return nil, ErrUnsupportedOSVersion
+	if err := macOSAvailable(11); err != nil {
+		return nil, err
 	}
 
 	config := &VirtioBlockDeviceConfiguration{
@@ -148,11 +148,11 @@ type USBMassStorageDeviceConfiguration struct {
 // NewUSBMassStorageDeviceConfiguration initialize a USBMassStorageDeviceConfiguration
 // with a device attachment.
 //
-// This is only supported on macOS 13 and newer, ErrUnsupportedOSVersion will
+// This is only supported on macOS 13 and newer, error will
 // be returned on older versions.
 func NewUSBMassStorageDeviceConfiguration(attachment StorageDeviceAttachment) (*USBMassStorageDeviceConfiguration, error) {
-	if macosMajorVersionLessThan(13) {
-		return nil, ErrUnsupportedOSVersion
+	if err := macOSAvailable(13); err != nil {
+		return nil, err
 	}
 	usbMass := &USBMassStorageDeviceConfiguration{
 		pointer: objc.NewPointer(

--- a/virtualization_arm64.go
+++ b/virtualization_arm64.go
@@ -30,12 +30,12 @@ import (
 // WithStartUpFromMacOSRecovery is an option to specifiy whether to start up
 // from macOS Recovery for macOS VM.
 //
-// This is only supported on macOS 13 and newer, ErrUnsupportedOSVersion will
+// This is only supported on macOS 13 and newer, error will
 // be returned on older versions.
 func WithStartUpFromMacOSRecovery(startInRecovery bool) VirtualMachineStartOption {
 	return func(vmso *virtualMachineStartOptions) error {
-		if macosMajorVersionLessThan(13) {
-			return ErrUnsupportedOSVersion
+		if err := macOSAvailable(13); err != nil {
+			return err
 		}
 		vmso.macOSVirtualMachineStartOptionsPtr = C.newVZMacOSVirtualMachineStartOptions(
 			C.bool(startInRecovery),
@@ -54,7 +54,7 @@ type MacHardwareModel struct {
 
 // NewMacHardwareModelWithDataPath initialize a new hardware model described by the specified pathname.
 //
-// This is only supported on macOS 12 and newer, ErrUnsupportedOSVersion will
+// This is only supported on macOS 12 and newer, error will
 // be returned on older versions.
 func NewMacHardwareModelWithDataPath(pathname string) (*MacHardwareModel, error) {
 	b, err := os.ReadFile(pathname)
@@ -66,11 +66,11 @@ func NewMacHardwareModelWithDataPath(pathname string) (*MacHardwareModel, error)
 
 // NewMacHardwareModelWithData initialize a new hardware model described by the specified data representation.
 //
-// This is only supported on macOS 12 and newer, ErrUnsupportedOSVersion will
+// This is only supported on macOS 12 and newer, error will
 // be returned on older versions.
 func NewMacHardwareModelWithData(b []byte) (*MacHardwareModel, error) {
-	if macosMajorVersionLessThan(12) {
-		return nil, ErrUnsupportedOSVersion
+	if err := macOSAvailable(12); err != nil {
+		return nil, err
 	}
 
 	ptr := C.newVZMacHardwareModelWithBytes(
@@ -112,7 +112,7 @@ type MacMachineIdentifier struct {
 
 // NewMacMachineIdentifierWithDataPath initialize a new machine identifier described by the specified pathname.
 //
-// This is only supported on macOS 12 and newer, ErrUnsupportedOSVersion will
+// This is only supported on macOS 12 and newer, error will
 // be returned on older versions.
 func NewMacMachineIdentifierWithDataPath(pathname string) (*MacMachineIdentifier, error) {
 	b, err := os.ReadFile(pathname)
@@ -124,11 +124,11 @@ func NewMacMachineIdentifierWithDataPath(pathname string) (*MacMachineIdentifier
 
 // NewMacMachineIdentifierWithData initialize a new machine identifier described by the specified data representation.
 //
-// This is only supported on macOS 12 and newer, ErrUnsupportedOSVersion will
+// This is only supported on macOS 12 and newer, error will
 // be returned on older versions.
 func NewMacMachineIdentifierWithData(b []byte) (*MacMachineIdentifier, error) {
-	if macosMajorVersionLessThan(12) {
-		return nil, ErrUnsupportedOSVersion
+	if err := macOSAvailable(12); err != nil {
+		return nil, err
 	}
 
 	ptr := C.newVZMacMachineIdentifierWithBytes(
@@ -147,11 +147,11 @@ func NewMacMachineIdentifierWithData(b []byte) (*MacMachineIdentifier, error) {
 // DataRepresentation method.
 // The identifier can then be recreated with NewMacMachineIdentifierWithData function from the binary representation.
 //
-// This is only supported on macOS 12 and newer, ErrUnsupportedOSVersion will
+// This is only supported on macOS 12 and newer, error will
 // be returned on older versions.
 func NewMacMachineIdentifier() (*MacMachineIdentifier, error) {
-	if macosMajorVersionLessThan(12) {
-		return nil, ErrUnsupportedOSVersion
+	if err := macOSAvailable(12); err != nil {
+		return nil, err
 	}
 	return newMacMachineIdentifier(C.newVZMacMachineIdentifier()), nil
 }
@@ -206,11 +206,11 @@ func WithCreatingStorage(hardwareModel *MacHardwareModel) NewMacAuxiliaryStorage
 // NewMacAuxiliaryStorage creates a new MacAuxiliaryStorage is based Mac auxiliary storage data from the storagePath
 // of an existing file by default.
 //
-// This is only supported on macOS 12 and newer, ErrUnsupportedOSVersion will
+// This is only supported on macOS 12 and newer, error will
 // be returned on older versions.
 func NewMacAuxiliaryStorage(storagePath string, opts ...NewMacAuxiliaryStorageOption) (*MacAuxiliaryStorage, error) {
-	if macosMajorVersionLessThan(12) {
-		return nil, ErrUnsupportedOSVersion
+	if err := macOSAvailable(12); err != nil {
+		return nil, err
 	}
 
 	storage := &MacAuxiliaryStorage{storagePath: storagePath}
@@ -396,11 +396,11 @@ func downloadRestoreImage(ctx context.Context, url string, destPath string) (*pr
 // After downloading the restore image, you can initialize a MacOSInstaller using LoadMacOSRestoreImageFromPath function
 // with the local restore image file.
 //
-// This is only supported on macOS 12 and newer, ErrUnsupportedOSVersion will
+// This is only supported on macOS 12 and newer, error will
 // be returned on older versions.
 func FetchLatestSupportedMacOSRestoreImage(ctx context.Context, destPath string) (*progress.Reader, error) {
-	if macosMajorVersionLessThan(12) {
-		return nil, ErrUnsupportedOSVersion
+	if err := macOSAvailable(12); err != nil {
+		return nil, err
 	}
 
 	waitCh := make(chan struct{})
@@ -432,11 +432,11 @@ func FetchLatestSupportedMacOSRestoreImage(ctx context.Context, destPath string)
 //
 // If the imagePath parameter doesn’t refer to a local file, the system raises an exception via Objective-C.
 //
-// This is only supported on macOS 12 and newer, ErrUnsupportedOSVersion will
+// This is only supported on macOS 12 and newer, error will
 // be returned on older versions.
 func LoadMacOSRestoreImageFromPath(imagePath string) (retImage *MacOSRestoreImage, retErr error) {
-	if macosMajorVersionLessThan(12) {
-		return nil, ErrUnsupportedOSVersion
+	if err := macOSAvailable(12); err != nil {
+		return nil, err
 	}
 	if _, err := os.Stat(imagePath); err != nil {
 		return nil, err
@@ -474,11 +474,11 @@ type MacOSInstaller struct {
 // A param vm is the virtual machine that the operating system will be installed onto.
 // A param restoreImageIpsw is a file path indicating the macOS restore image to install.
 //
-// This is only supported on macOS 12 and newer, ErrUnsupportedOSVersion will
+// This is only supported on macOS 12 and newer, error will
 // be returned on older versions.
 func NewMacOSInstaller(vm *VirtualMachine, restoreImageIpsw string) (*MacOSInstaller, error) {
-	if macosMajorVersionLessThan(12) {
-		return nil, ErrUnsupportedOSVersion
+	if err := macOSAvailable(12); err != nil {
+		return nil, err
 	}
 	if _, err := os.Stat(restoreImageIpsw); err != nil {
 		return nil, err

--- a/virtualization_export_test.go
+++ b/virtualization_export_test.go
@@ -1,5 +1,5 @@
 package vz
 
-func MacosMajorVersionLessThan(version float64) bool {
-	return macosMajorVersionLessThan(version)
+func Available(version float64) bool {
+	return macOSAvailable(version) != nil
 }

--- a/virtualization_export_test.go
+++ b/virtualization_export_test.go
@@ -1,5 +1,5 @@
 package vz
 
-func MacosMajorVersionLessThan(version int) bool {
+func MacosMajorVersionLessThan(version float64) bool {
 	return macosMajorVersionLessThan(version)
 }

--- a/virtualization_helper.h
+++ b/virtualization_helper.h
@@ -24,7 +24,8 @@ NSDictionary *dumpProcessinfo();
 #pragma message("macOS 13 API has been disabled")
 #endif
 
-static inline int mac_os_x_version_max_allowed() {
+static inline int mac_os_x_version_max_allowed()
+{
 #ifdef __MAC_OS_X_VERSION_MAX_ALLOWED
     return __MAC_OS_X_VERSION_MAX_ALLOWED;
 #else

--- a/virtualization_helper.h
+++ b/virtualization_helper.h
@@ -24,6 +24,14 @@ NSDictionary *dumpProcessinfo();
 #pragma message("macOS 13 API has been disabled")
 #endif
 
+static inline int mac_os_x_version_max_allowed() {
+#ifdef __MAC_OS_X_VERSION_MAX_ALLOWED
+    return __MAC_OS_X_VERSION_MAX_ALLOWED;
+#else
+    return 0;
+#endif
+}
+
 typedef struct nbyteslice {
     void *ptr;
     int len;

--- a/virtualization_test.go
+++ b/virtualization_test.go
@@ -172,7 +172,7 @@ func newVirtualizationMachine(
 	//
 	// This is a workaround. This version of the API does not immediately return an error and
 	// does not seem to have a connection timeout set.
-	if vz.MacosMajorVersionLessThan(12) {
+	if vz.Available(12) {
 		time.Sleep(5 * time.Second)
 	}
 
@@ -301,7 +301,7 @@ func TestRun(t *testing.T) {
 }
 
 func TestStop(t *testing.T) {
-	if vz.MacosMajorVersionLessThan(12) {
+	if vz.Available(12) {
 		t.Skip("Stop is supported from macOS 12")
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/Code-Hex/vz/blob/master/CONTRIBUTING.md
2. Please create a new issue before creating this PR. However, You can continue it without creating issues if this PR fixes any documentations such as typo.
3. Do not send Pull Requests for large (150 ~ lines) code changes. If so, I am not motivated to review your code. Basically, I write the code.
-->

## Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #101 

## Additional documentation

<!--
This section can be blank.
-->

A mechanism has been introduced to determine in runtime whether the program being executed has been compiled with the API enabled. The following situations can be avoided, but the new API must be compiled with the corresponding SDK.

1. compile a program with Xcode SDK 13.2.1 on macOS 11.3+ (with warning: macOS 13 API has been disabled)
2. use the program on macOS 13 for macOS 13 API
3. throw exception
