### PR TITLE
mcaOSBuildTargetAvailable(): include __MAC_OS_X_VERSION_MAX_ALLOWED in error

### DIFF
--- a/osversion.go
+++ b/osversion.go
@@ -105,7 +105,8 @@ func macOSBuildTargetAvailable(version float64) error {
 		target = 130000 // __MAC_13_0
 	}
 	if allowedVersion < target {
-		return fmt.Errorf("%w for %.1f", ErrBuildTargetOSVersion, version)
+		return fmt.Errorf("%w for %.1f (the binary was built with __MAC_OS_X_VERSION_MAX_ALLOWED=%d; needs recompilation)",
+			ErrBuildTargetOSVersion, version, allowedVersion)
 	}
 	return nil
 }

--- a/osversion_test.go
+++ b/osversion_test.go
@@ -356,6 +356,10 @@ func Test_macOSBuildTargetAvailable(t *testing.T) {
 		maxAllowedVersionOnce = &sync.Once{}
 	}()
 
+	wantErrMsgFor := func(version float64, maxAllowedVersion int) string {
+		return fmt.Sprintf("for %.1f (the binary was built with __MAC_OS_X_VERSION_MAX_ALLOWED=%d; needs recompilation)", version, maxAllowedVersion)
+	}
+
 	cases := []struct {
 		// version is specified only 11, 12, 12.3, 13
 		version           float64
@@ -373,7 +377,7 @@ func Test_macOSBuildTargetAvailable(t *testing.T) {
 			version:           11,
 			maxAllowedVersion: 100000,
 			wantErr:           true,
-			wantErrMsg:        "for 11.0",
+			wantErrMsg:        wantErrMsgFor(11, 100000),
 		},
 		{
 			version:           11,
@@ -383,7 +387,7 @@ func Test_macOSBuildTargetAvailable(t *testing.T) {
 			version:           12,
 			maxAllowedVersion: 110000,
 			wantErr:           true,
-			wantErrMsg:        "for 12.0",
+			wantErrMsg:        wantErrMsgFor(12, 110000),
 		},
 		{
 			version:           12,
@@ -409,7 +413,7 @@ func Test_macOSBuildTargetAvailable(t *testing.T) {
 			version:           12.3,
 			maxAllowedVersion: 120000,
 			wantErr:           true,
-			wantErrMsg:        "for 12.3",
+			wantErrMsg:        wantErrMsgFor(12.3, 120000),
 		},
 		{
 			version:           12.3,
@@ -423,7 +427,7 @@ func Test_macOSBuildTargetAvailable(t *testing.T) {
 			version:           13,
 			maxAllowedVersion: 120300,
 			wantErr:           true,
-			wantErrMsg:        "for 13.0",
+			wantErrMsg:        wantErrMsgFor(13, 120300),
 		},
 		{
 			version:           13,


### PR DESCRIPTION

Should be helpful for analyzing issues like lima-vm/lima#1182


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/Code-Hex/vz/blob/master/CONTRIBUTING.md
2. Please create a new issue before creating this PR. However, You can continue it without creating issues if this PR fixes any documentations such as typo.
3. Do not send Pull Requests for large (150 ~ lines) code changes. If so, I am not motivated to review your code. Basically, I write the code.
-->

## Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Helpful for (but does not "fix"):
- lima-vm/lima#1182

## Additional documentation

<!--
This section can be blank.
-->
