### PR TITLE
chore: fix spelling and error strings should not be capitalized

### DIFF
--- a/bootloader.go
+++ b/bootloader.go
@@ -192,7 +192,7 @@ func WithCreatingEFIVariableStore() NewEFIVariableStoreOption {
 }
 
 // NewEFIVariableStore Initialize the variable store. If no options are specified,
-// it initialises from the paths that exist.
+// it initializes from the paths that exist.
 //
 // This is only supported on macOS 13 and newer, error will
 // be returned on older versions.

--- a/network.go
+++ b/network.go
@@ -166,7 +166,7 @@ func validateDatagramSocket(fd int) error {
 	if sotype == syscall.SOCK_DGRAM && isAvailableDatagram(fd) {
 		return nil
 	}
-	return fmt.Errorf("The fileHandle must be a datagram socket")
+	return fmt.Errorf("the fileHandle must be a datagram socket")
 }
 
 func isAvailableDatagram(fd int) bool {

--- a/serial_console.go
+++ b/serial_console.go
@@ -37,7 +37,7 @@ type FileHandleSerialPortAttachment struct {
 	*baseSerialPortAttachment
 }
 
-// NewFileHandleSerialPortAttachment intialize the FileHandleSerialPortAttachment from file handles.
+// NewFileHandleSerialPortAttachment initialize the FileHandleSerialPortAttachment from file handles.
 //
 // read parameter is an *os.File for reading from the file.
 // write parameter is an *os.File for writing to the file.

--- a/socket.go
+++ b/socket.go
@@ -138,7 +138,7 @@ func connectionHandler(connPtr, errPtr, cgoHandlerPtr unsafe.Pointer) {
 // Connect Initiates a connection to the specified port of the guest operating system.
 //
 // This method initiates the connection asynchronously, and executes the completion handler when the results are available.
-// If the guest operating system doesn’t listen for connections to the specifed port, this method does nothing.
+// If the guest operating system doesn’t listen for connections to the specified port, this method does nothing.
 //
 // For a successful connection, this method sets the sourcePort property of the resulting VZVirtioSocketConnection object to a random port number.
 // see: https://developer.apple.com/documentation/virtualization/vzvirtiosocketdevice/3656677-connecttoport?language=objc


### PR DESCRIPTION
Small PR for typos and capitalization.

Signed-off-by: Ryan Currah <ryan@currah.ca>
