### PR TITLE
fixed calling deleteStateHandler after called dealloc of VZVirtualMachine

### DIFF
--- a/virtualization_11.m
+++ b/virtualization_11.m
@@ -10,18 +10,9 @@
 - (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context;
 {
 
-    @autoreleasepool {
-        if ([keyPath isEqualToString:@"state"]) {
-            int newState = (int)[change[NSKeyValueChangeNewKey] integerValue];
-            changeStateOnObserver(newState, context);
-        } else {
-            // bool canVal = (bool)[change[NSKeyValueChangeNewKey] boolValue];
-            // char *vmid = copyCString((NSString *)context);
-            // char *key = copyCString(keyPath);
-            // changeCanPropertyOnObserver(canVal, vmid, key);
-            // free(vmid);
-            // free(key);
-        }
+    if ([keyPath isEqualToString:@"state"]) {
+        int newState = (int)[change[NSKeyValueChangeNewKey] integerValue];
+        changeStateOnObserver(newState, context);
     }
 }
 @end
@@ -46,9 +37,9 @@
 - (void)dealloc
 {
     [self removeObserver:_observer forKeyPath:@"state"];
-    deleteStateHandler(_stateHandler);
     [_observer release];
     [super dealloc];
+    deleteStateHandler(_stateHandler);
 }
 @end
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/Code-Hex/vz/blob/master/CONTRIBUTING.md
2. Please create a new issue before creating this PR. However, You can continue it without creating issues if this PR fixes any documentations such as typo.
3. Do not send Pull Requests for large (150 ~ lines) code changes. If so, I am not motivated to review your code. Basically, I write the code.
-->

## Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #124

## Additional documentation

The problem is that state detection is working even though the handler has been removed.
I will not delete this handler until the Objective-C VZVirtualMachine object is freed in this PR.

I don't have the reproduction code to hand, so we'll have to wait and see.

<!--
This section can be blank.
-->
