### PR TITLE
gui: Watch vm state to terminate when it's stopped

### DIFF
--- a/example/gui-linux/main.go
+++ b/example/gui-linux/main.go
@@ -77,6 +77,17 @@ func run(ctx context.Context) error {
 		}
 	}()
 
+	go func() {
+		if !vm.CanStop() {
+			log.Println("cannot stop vm forcefully")
+			return
+		}
+		time.Sleep(10 * time.Second)
+		log.Println("calling vm.Stop()")
+
+		vm.Stop()
+	}()
+
 	// cleanup is this function is useful when finished graphic application.
 	cleanup := func() {
 		for i := 1; vm.CanRequestStop(); i++ {

--- a/virtualization_view.m
+++ b/virtualization_view.m
@@ -165,11 +165,30 @@
 
 @end
 
+API_AVAILABLE(macos(12.0))
+@interface VMStateObserver : NSObject
+- (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context;
+@end
+
+@implementation VMStateObserver
+- (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context;
+{
+    if ([keyPath isEqualToString:@"state"]) {
+        int newState = (int)[change[NSKeyValueChangeNewKey] integerValue];
+        if (newState == VZVirtualMachineStateStopped || newState == VZVirtualMachineStateError) {
+            [NSApp performSelectorOnMainThread:@selector(terminate:) withObject:context waitUntilDone:NO];
+            [object removeObserver:self forKeyPath:@"state"];
+        }
+    }
+}
+@end
+
 @implementation AppDelegate {
     VZVirtualMachine *_virtualMachine;
     VZVirtualMachineView *_virtualMachineView;
     CGFloat _windowWidth;
     CGFloat _windowHeight;
+    VMStateObserver *_observer;
 }
 
 - (instancetype)initWithVirtualMachine:(VZVirtualMachine *)virtualMachine
@@ -179,6 +198,11 @@
     self = [super init];
     _virtualMachine = virtualMachine;
     [_virtualMachine setDelegate:self];
+    _observer = [[VMStateObserver alloc] init];
+    [virtualMachine addObserver:_observer
+           forKeyPath:@"state"
+              options:NSKeyValueObservingOptionNew
+              context:(void *)self];
 
     // Setup virtual machine view configs
     VZVirtualMachineView *view = [[[VZVirtualMachineView alloc] init] autorelease];


### PR DESCRIPTION
The GUI code in virtualization_view.m is notified when there was a guest 
initiated shutdown ('guestDidStopVirtualMachine') and when there was a 
virtualization error ('didStopWithError').

When calling Stop(), the VM is forcefully stopped (similar to pulling the
plug on real hardware). This action is neither a guest initiated shutdown,
nor a virtualization error, so the GUI code does not catch it. This means
after calling vm.Stop(), the GUI main loop will keep running, and the
application using Code-Hex/vz will never exit.

This commit fixes this by adding an observer for VM state changes, and by
calling 'terminate' when the VM state becomes 'stopped' or 'error'.



<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/Code-Hex/vz/blob/master/CONTRIBUTING.md
2. Please create a new issue before creating this PR. However, You can continue it without creating issues if this PR fixes any documentations such as typo.
3. Do not send Pull Requests for large (150 ~ lines) code changes. If so, I am not motivated to review your code. Basically, I write the code.
-->

## Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #150

## Additional documentation

The first commit in this PR allows to reproduce the issue using gui-linux

<!--
This section can be blank.
-->