### PR TITLE
added VZNetworkBlockDeviceStorageDeviceAttachment

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -15,40 +15,59 @@ jobs:
     name: Formatting Check
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Run clang-format style check for Objective-C files.
-      uses: jidicula/clang-format-action@v4.8.0
+      uses: jidicula/clang-format-action@v4.13.0
       with:
         clang-format-version: '13'
   build:
     needs: formatting-check
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 6
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
         os:
-        - macOS-11
-        - macOS-12
-        - macOS-13
+        - macos-13  # Intel
+        - macos-14-large  # Intel
+        - macos-15-large  # Intel
         go:
-        - '^1.20'
-        - '^1.21'
+        - '^1.22'
+        - '^1.23'
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go }}
       - name: vet
         run: go vet ./...
-      - name: Download Linux kernel
-        run: make download_kernel
-      - name: Unit Test
-        run: make test
-        timeout-minutes: 3
       - name: Build Linux
         run: make -C example/linux
       - name: Build GUI Linux
         run: make -C example/gui-linux
+  test:
+    needs: build
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      # Can't expand the matrix due to the flakiness of the CI infra
+      matrix:
+        os:
+        - macos-15-large  # Intel
+        go:
+        - '^1.23'
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go }}
+      - name: Download Linux kernel
+        run: make download_kernel
+      - name: Unit Test
+        run: make test
+        timeout-minutes: 10

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -29,8 +29,8 @@ jobs:
       matrix:
         os:
         - macos-13  # Intel
-        - macos-14-large  # Intel
-        - macos-15-large  # Intel
+        - macos-14
+        - macos-15
         go:
         - '^1.22'
         - '^1.23'
@@ -56,7 +56,7 @@ jobs:
       # Can't expand the matrix due to the flakiness of the CI infra
       matrix:
         os:
-        - macos-15-large  # Intel
+        - macos-15
         go:
         - '^1.23'
     steps:

--- a/osversion.go
+++ b/osversion.go
@@ -105,6 +105,8 @@ func macOSBuildTargetAvailable(version float64) error {
 		target = 130000 // __MAC_13_0
 	case 14:
 		target = 140000 // __MAC_14_0
+	case 15:
+		target = 150000 // __MAC_15_0
 	}
 	if allowedVersion < target {
 		return fmt.Errorf("%w for %.1f (the binary was built with __MAC_OS_X_VERSION_MAX_ALLOWED=%d; needs recompilation)",

--- a/osversion_test.go
+++ b/osversion_test.go
@@ -319,6 +319,10 @@ func TestAvailableVersion(t *testing.T) {
 				_, err := NewDiskBlockDeviceStorageDeviceAttachment(nil, false, DiskSynchronizationModeFull)
 				return err
 			},
+			"NewNetworkBlockDeviceStorageDeviceAttachment": func() error {
+				_, err := NewNetworkBlockDeviceStorageDeviceAttachment("", 0, false, DiskSynchronizationModeFull)
+				return err
+			},
 		}
 		for name, fn := range cases {
 			t.Run(name, func(t *testing.T) {

--- a/platform.go
+++ b/platform.go
@@ -6,6 +6,7 @@ package vz
 # include "virtualization_11.h"
 # include "virtualization_12.h"
 # include "virtualization_13.h"
+# include "virtualization_15.h"
 */
 import "C"
 import (
@@ -38,6 +39,28 @@ type GenericPlatformConfiguration struct {
 // MachineIdentifier returns the machine identifier.
 func (m *GenericPlatformConfiguration) MachineIdentifier() *GenericMachineIdentifier {
 	return m.machineIdentifier
+}
+
+// IsNestedVirtualizationSupported reports if nested virtualization is supported.
+func IsNestedVirtualizationSupported() bool {
+	if err := macOSAvailable(15); err != nil {
+		return false
+	}
+
+	return (bool)(C.isNestedVirtualizationSupported())
+}
+
+// SetNestedVirtualizationEnabled toggles nested virtualization.
+func (m *GenericPlatformConfiguration) SetNestedVirtualizationEnabled(enable bool) error {
+	if err := macOSAvailable(15); err != nil {
+		return err
+	}
+
+	C.setNestedVirtualizationEnabled(
+		objc.Ptr(m),
+		C.bool(enable),
+	)
+	return nil
 }
 
 var _ PlatformConfiguration = (*GenericPlatformConfiguration)(nil)

--- a/virtualization_14.h
+++ b/virtualization_14.h
@@ -16,3 +16,4 @@
 /* macOS 14 API */
 void *newVZNVMExpressControllerDeviceConfiguration(void *attachment);
 void *newVZDiskBlockDeviceStorageDeviceAttachment(int fileDescriptor, bool readOnly, int syncMode, void **error);
+void *newVZNetworkBlockDeviceStorageDeviceAttachment(const char *url, double timeout, bool forcedReadOnly, int syncMode, void **error);

--- a/virtualization_14.m
+++ b/virtualization_14.m
@@ -51,3 +51,36 @@ void *newVZDiskBlockDeviceStorageDeviceAttachment(int fileDescriptor, bool readO
 #endif
     RAISE_UNSUPPORTED_MACOS_EXCEPTION();
 }
+
+/*!
+ @abstract Initialize a network block device storage attachment from an NBD URI.
+ @param uri The NBD’s URI represented as a URL.
+ @param timeout The timeout value in seconds for the connection between the client and server. When the timeout expires, an attempt to reconnect with the server takes place.
+ @param forcedReadOnly If YES, the framework forces the disk attachment to be read-only, regardless of whether or not the NBD server supports write requests.
+ @param synchronizationMode Defines how the disk synchronizes with the underlying storage when the guest operating system flushes data.
+ @param error If not nil, assigned with the error if the initialization failed.
+ @return An initialized `VZDiskBlockDeviceStorageDeviceAttachment` or nil if there was an error.
+ @discussion
+    The forcedReadOnly parameter affects how framework exposes the NBD client to the guest operating
+    system by the storage controller. As part of the NBD protocol, the NBD server advertises whether
+    or not the disk exposed by the NBD client is read-only during the handshake phase of the protocol.
+
+    Setting forcedReadOnly to YES forces the NBD client to show up as read-only to the guest
+    regardless of whether or not the NBD server advertises itself as read-only.
+ */
+void *newVZNetworkBlockDeviceStorageDeviceAttachment(const char *uri, double timeout, bool forcedReadOnly, int syncMode, void **error)
+{
+#ifdef INCLUDE_TARGET_OSX_14
+    if (@available(macOS 14, *)) {
+        NSURL *url = [NSURL URLWithString:[NSString stringWithUTF8String:uri]];
+
+        return [[VZNetworkBlockDeviceStorageDeviceAttachment alloc]
+                    initWithURL:url
+                        timeout:(NSTimeInterval)timeout
+                 forcedReadOnly:(BOOL)forcedReadOnly
+            synchronizationMode:(VZDiskSynchronizationMode)syncMode
+                          error:(NSError *_Nullable *_Nullable)error];
+    }
+#endif
+    RAISE_UNSUPPORTED_MACOS_EXCEPTION();
+}

--- a/virtualization_15.h
+++ b/virtualization_15.h
@@ -1,0 +1,15 @@
+//
+//  virtualization_15.h
+
+#pragma once
+
+// FIXME(codehex): this is dirty hack to avoid clang-format error like below
+// "Configuration file(s) do(es) not support C++: /github.com/Code-Hex/vz/.clang-format"
+#define NSURLComponents NSURLComponents
+
+#import "virtualization_helper.h"
+#import <Virtualization/Virtualization.h>
+
+/* macOS 15 API */
+bool isNestedVirtualizationSupported();
+void setNestedVirtualizationEnabled(void *config, bool nestedVirtualizationEnabled);

--- a/virtualization_15.m
+++ b/virtualization_15.m
@@ -1,0 +1,33 @@
+//
+//  virtualization_15.m
+//
+#import "virtualization_15.h"
+
+/*!
+ @abstract Check if nested virtualization is supported.
+ @return true if supported.
+ */
+bool isNestedVirtualizationSupported()
+{
+#ifdef INCLUDE_TARGET_OSX_15
+    if (@available(macOS 15, *)) {
+        return (bool) VZGenericPlatformConfiguration.isNestedVirtualizationSupported;
+    }
+#endif
+    RAISE_UNSUPPORTED_MACOS_EXCEPTION();
+}
+
+/*!
+ @abstract Set nestedVirtualizationEnabled. The default is false.
+ */
+void setNestedVirtualizationEnabled(void *config, bool nestedVirtualizationEnabled)
+{
+#ifdef INCLUDE_TARGET_OSX_15
+    if (@available(macOS 15, *)) {
+        VZGenericPlatformConfiguration *platformConfig = (VZGenericPlatformConfiguration *)config;
+        platformConfig.nestedVirtualizationEnabled = (BOOL) nestedVirtualizationEnabled;
+        return;
+    }
+#endif
+    RAISE_UNSUPPORTED_MACOS_EXCEPTION();
+}

--- a/virtualization_helper.h
+++ b/virtualization_helper.h
@@ -39,6 +39,13 @@ NSDictionary *dumpProcessinfo();
 #pragma message("macOS 14 API has been disabled")
 #endif
 
+// for macOS 15 API
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 150000
+#define INCLUDE_TARGET_OSX_15 1
+#else
+#pragma message("macOS 15 API has been disabled")
+#endif
+
 static inline int mac_os_x_version_max_allowed()
 {
 #ifdef __MAC_OS_X_VERSION_MAX_ALLOWED


### PR DESCRIPTION
Further to https://github.com/Code-Hex/vz/pull/142, this adds [VZNetworkBlockDeviceStorageDeviceAttachment](https://developer.apple.com/documentation/virtualization/vznetworkblockdevicestoragedeviceattachment?language=objc) support.

This PR lacks setting a [delegate](https://developer.apple.com/documentation/virtualization/vznetworkblockdevicestoragedeviceattachment/4168502-delegate?language=objc) to monitor state changes to the attachment, mostly because I couldn't figure out the best way to integrate this and it would probably lead to a much larger PR. Hopefully that can be done in a follow-up.

I've updated the MacOS application to ease testing. You can serve an existing raw disk within the bundle directory with `qemu-nbd`:

```shell
qemu-nbd -k $(pwd)/source.sock -f raw -x export --cache=none disk.img
```

And then run:

```
./macOS -nbd-url "nbd+unix:///export?socket=source.sock"
```

The `-install` option also works well with this argument if you serve a disk created with `qemu-img`.

This is great news as it gives access to `qemu`'s `qcow2` format and linked disks functionality.

Relates to https://github.com/Code-Hex/vz/issues/143