### PR TITLE
add support for VZNetworkBlockDeviceStorageDeviceAttachmentDelegate

### DIFF
--- a/configuration.go
+++ b/configuration.go
@@ -174,6 +174,20 @@ func (v *VirtualMachineConfiguration) SetStorageDevicesVirtualMachineConfigurati
 	C.setStorageDevicesVZVirtualMachineConfiguration(objc.Ptr(v), objc.Ptr(array))
 }
 
+// StorageDevices return the list of storage device configuration configured in this virtual machine configuration.
+// Return an empty array if no storage device configuration is set.
+func (v *VirtualMachineConfiguration) StorageDevices() []StorageDeviceConfiguration {
+	nsArray := objc.NewNSArray(
+		C.storageDevicesVZVirtualMachineConfiguration(objc.Ptr(v)),
+	)
+	ptrs := nsArray.ToPointerSlice()
+	storageDevices := make([]StorageDeviceConfiguration, len(ptrs))
+	for i, ptr := range ptrs {
+		storageDevices[i] = newVirtioBlockDeviceConfiguration(ptr)
+	}
+	return storageDevices
+}
+
 // SetDirectorySharingDevicesVirtualMachineConfiguration sets list of directory sharing devices. Empty by default.
 //
 // This is only supported on macOS 12 and newer. Older versions do nothing.

--- a/storage.go
+++ b/storage.go
@@ -210,6 +210,12 @@ func NewVirtioBlockDeviceConfiguration(attachment StorageDeviceAttachment) (*Vir
 	return config, nil
 }
 
+func newVirtioBlockDeviceConfiguration(ptr unsafe.Pointer) *VirtioBlockDeviceConfiguration {
+	return &VirtioBlockDeviceConfiguration{
+		pointer: objc.NewPointer(ptr),
+	}
+}
+
 // BlockDeviceIdentifier returns the device identifier is a string identifying the Virtio block device.
 // Empty string by default.
 //

--- a/virtualization_11.h
+++ b/virtualization_11.h
@@ -59,6 +59,7 @@ void setSocketDevicesVZVirtualMachineConfiguration(void *config,
 void *socketDevicesVZVirtualMachineConfiguration(void *config);
 void setStorageDevicesVZVirtualMachineConfiguration(void *config,
     void *storageDevices);
+void *storageDevicesVZVirtualMachineConfiguration(void *config);
 
 /* Configurations */
 void *newVZFileHandleSerialPortAttachment(int readFileDescriptor, int writeFileDescriptor);

--- a/virtualization_11.m
+++ b/virtualization_11.m
@@ -328,6 +328,18 @@ void setStorageDevicesVZVirtualMachineConfiguration(void *config,
 }
 
 /*!
+ @abstract Return the list of storage devices configurations for this VZVirtualMachineConfiguration. Return an empty array if no storage device configuration is set.
+ */
+void *storageDevicesVZVirtualMachineConfiguration(void *config)
+{
+    if (@available(macOS 11, *)) {
+        return [(VZVirtualMachineConfiguration *)config storageDevices]; // NSArray<VZStorageDeviceConfiguration *>
+    }
+
+    RAISE_UNSUPPORTED_MACOS_EXCEPTION();
+}
+
+/*!
  @abstract Intialize the VZFileHandleSerialPortAttachment from file descriptors.
  @param readFileDescriptor File descriptor for reading from the file.
  @param writeFileDescriptor File descriptor for writing to the file.

--- a/virtualization_14.h
+++ b/virtualization_14.h
@@ -13,7 +13,17 @@
 #import "virtualization_helper.h"
 #import <Virtualization/Virtualization.h>
 
+/* exported from cgo */
+void attachmentHandler(uintptr_t cgoHandle, void *err);
+void attachmentWasConnectedHandler(uintptr_t cgoHandle);
+
 /* macOS 14 API */
 void *newVZNVMExpressControllerDeviceConfiguration(void *attachment);
 void *newVZDiskBlockDeviceStorageDeviceAttachment(int fileDescriptor, bool readOnly, int syncMode, void **error);
-void *newVZNetworkBlockDeviceStorageDeviceAttachment(const char *url, double timeout, bool forcedReadOnly, int syncMode, void **error);
+void *newVZNetworkBlockDeviceStorageDeviceAttachment(const char *url, double timeout, bool forcedReadOnly, int syncMode, void **error, uintptr_t cgoHandle);
+
+@interface VZNetworkBlockDeviceStorageDeviceAttachmentDelegateImpl : NSObject <VZNetworkBlockDeviceStorageDeviceAttachmentDelegate>
+- (instancetype)initWithHandle:(uintptr_t)cgoHandle;
+- (void)attachment:(VZNetworkBlockDeviceStorageDeviceAttachment *)attachment didEncounterError:(NSError *)error;
+- (void)attachmentWasConnected:(VZNetworkBlockDeviceStorageDeviceAttachment *)attachment;
+@end

--- a/virtualization_14.m
+++ b/virtualization_14.m
@@ -68,19 +68,48 @@ void *newVZDiskBlockDeviceStorageDeviceAttachment(int fileDescriptor, bool readO
     Setting forcedReadOnly to YES forces the NBD client to show up as read-only to the guest
     regardless of whether or not the NBD server advertises itself as read-only.
  */
-void *newVZNetworkBlockDeviceStorageDeviceAttachment(const char *uri, double timeout, bool forcedReadOnly, int syncMode, void **error)
+void *newVZNetworkBlockDeviceStorageDeviceAttachment(const char *uri, double timeout, bool forcedReadOnly, int syncMode, void **error, uintptr_t cgoHandle)
 {
 #ifdef INCLUDE_TARGET_OSX_14
     if (@available(macOS 14, *)) {
         NSURL *url = [NSURL URLWithString:[NSString stringWithUTF8String:uri]];
 
-        return [[VZNetworkBlockDeviceStorageDeviceAttachment alloc]
+        VZNetworkBlockDeviceStorageDeviceAttachment *attachment = [[VZNetworkBlockDeviceStorageDeviceAttachment alloc]
                     initWithURL:url
                         timeout:(NSTimeInterval)timeout
                  forcedReadOnly:(BOOL)forcedReadOnly
             synchronizationMode:(VZDiskSynchronizationMode)syncMode
                           error:(NSError *_Nullable *_Nullable)error];
+
+        if (attachment) {
+            [attachment setDelegate:[[[VZNetworkBlockDeviceStorageDeviceAttachmentDelegateImpl alloc] initWithHandle:cgoHandle] autorelease]];
+        }
+
+        return attachment;
     }
 #endif
     RAISE_UNSUPPORTED_MACOS_EXCEPTION();
 }
+
+@implementation VZNetworkBlockDeviceStorageDeviceAttachmentDelegateImpl {
+    uintptr_t _cgoHandle;
+}
+
+- (instancetype)initWithHandle:(uintptr_t)cgoHandle
+{
+    self = [super init];
+    _cgoHandle = cgoHandle;
+    return self;
+}
+
+- (void)attachment:(VZNetworkBlockDeviceStorageDeviceAttachment *)attachment didEncounterError:(NSError *)error
+{
+    attachmentHandler(_cgoHandle, error);
+}
+
+- (void)attachmentWasConnected:(VZNetworkBlockDeviceStorageDeviceAttachment *)attachment
+{
+    attachmentWasConnectedHandler(_cgoHandle);
+}
+@end
+


### PR DESCRIPTION
this adds support for the VZNetworkBlockDeviceStorageDeviceAttachmentDelegate to being able to listen to changes to a network block device attachment.

## Which issue(s) this PR fixes:

Fixes #166 

## Additional documentation

I was supposed to add tests but then I noticed that you only run them on macOS 13 because macOS 14, 15 does not support build on nested virtualization. So I'm gonna mark the PR as ready to review. NBD support is only available from macOS 14+ . Please let me know if I should do something else.

My test use case below:
In the short vide I have a remote nbd server.
Then I create a vm connecting to the nbd server and works fine. The connection is made and the delegate receive the wasConnected message.
At this point, I stop the nbd server and I see the nbd client start receiving errors from the delegate as the connection dropped.
Then I start the nbd server again and my client gets reconnected.

https://github.com/user-attachments/assets/4025e774-69cd-4a1a-b3a8-306b5870b251


