### PR TITLE
added NetworkDeviceAttachmentWasDisconnected api

### DIFF
--- a/configuration.go
+++ b/configuration.go
@@ -38,6 +38,7 @@ type VirtualMachineConfiguration struct {
 	memorySize uint64
 	*pointer
 
+	networkDeviceConfiguration []*VirtioNetworkDeviceConfiguration
 	storageDeviceConfiguration []StorageDeviceConfiguration
 }
 
@@ -116,20 +117,13 @@ func (v *VirtualMachineConfiguration) SetNetworkDevicesVirtualMachineConfigurati
 	}
 	array := objc.ConvertToNSMutableArray(ptrs)
 	C.setNetworkDevicesVZVirtualMachineConfiguration(objc.Ptr(v), objc.Ptr(array))
+	v.networkDeviceConfiguration = cs
 }
 
 // NetworkDevices return the list of network device configuration set in this virtual machine configuration.
 // Return an empty array if no network device configuration is set.
 func (v *VirtualMachineConfiguration) NetworkDevices() []*VirtioNetworkDeviceConfiguration {
-	nsArray := objc.NewNSArray(
-		C.networkDevicesVZVirtualMachineConfiguration(objc.Ptr(v)),
-	)
-	ptrs := nsArray.ToPointerSlice()
-	networkDevices := make([]*VirtioNetworkDeviceConfiguration, len(ptrs))
-	for i, ptr := range ptrs {
-		networkDevices[i] = newVirtioNetworkDeviceConfiguration(ptr)
-	}
-	return networkDevices
+	return v.networkDeviceConfiguration
 }
 
 // SetSerialPortsVirtualMachineConfiguration sets list of serial ports. Empty by default.

--- a/internal/sliceutil/sliceutil.go
+++ b/internal/sliceutil/sliceutil.go
@@ -1,0 +1,12 @@
+package sliceutil
+
+// FindValueByIndex returns the value of the index in s,
+// or -1 if not present.
+func FindValueByIndex[S ~[]E, E any](s S, idx int) (v E) {
+	for i := range s {
+		if i == idx {
+			return s[i]
+		}
+	}
+	return v
+}

--- a/internal/sliceutil/sliceutil.go
+++ b/internal/sliceutil/sliceutil.go
@@ -1,12 +1,10 @@
 package sliceutil
 
 // FindValueByIndex returns the value of the index in s,
-// or -1 if not present.
+// or zero value if not present.
 func FindValueByIndex[S ~[]E, E any](s S, idx int) (v E) {
-	for i := range s {
-		if i == idx {
-			return s[i]
-		}
+	if idx < 0 || idx >= len(s) {
+		return v // return zero value of type E
 	}
-	return v
+	return s[idx]
 }

--- a/internal/sliceutil/sliceutil_test.go
+++ b/internal/sliceutil/sliceutil_test.go
@@ -1,0 +1,50 @@
+package sliceutil_test
+
+import (
+	"testing"
+
+	"github.com/Code-Hex/vz/v3/internal/sliceutil"
+)
+
+func TestFindValueByIndex(t *testing.T) {
+	tests := []struct {
+		name     string
+		slice    []int
+		index    int
+		expected int
+	}{
+		{
+			name:     "Index within range",
+			slice:    []int{1, 2, 3, 4, 5},
+			index:    2,
+			expected: 3,
+		},
+		{
+			name:     "Index out of range",
+			slice:    []int{1, 2, 3, 4, 5},
+			index:    10,
+			expected: 0, // default value of int
+		},
+		{
+			name:     "Negative index",
+			slice:    []int{1, 2, 3, 4, 5},
+			index:    -1,
+			expected: 0, // default value of int
+		},
+		{
+			name:     "Empty slice",
+			slice:    []int{},
+			index:    0,
+			expected: 0, // default value of int
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := sliceutil.FindValueByIndex(tt.slice, tt.index)
+			if result != tt.expected {
+				t.Errorf("FindValueByIndex(%v, %d) = %v; want %v", tt.slice, tt.index, result, tt.expected)
+			}
+		})
+	}
+}

--- a/virtualization.go
+++ b/virtualization.go
@@ -385,6 +385,8 @@ type DisconnectedError struct {
 	Config *VirtioNetworkDeviceConfiguration
 }
 
+var _ error = (*DisconnectedError)(nil)
+
 func (e *DisconnectedError) Unwrap() error { return e.Err }
 func (e *DisconnectedError) Error() string {
 	if e.Config == nil {

--- a/virtualization_11.h
+++ b/virtualization_11.h
@@ -45,7 +45,7 @@ void closeAttachmentWasDisconnectedChannel(uintptr_t cgoHandle);
                          networkDevice:(VZNetworkDevice *)networkDevice
     attachmentWasDisconnectedWithError:(NSError *)error API_AVAILABLE(macos(12.0));
 - (int)networkDevices:(NSArray<VZNetworkDevice *> *)networkDevices
-              indexOf:(VZNetworkDevice *)networkDevice;
+              indexOf:(VZNetworkDevice *)networkDevice API_AVAILABLE(macos(12.0));
 - (void)dealloc;
 @end
 

--- a/virtualization_11.m
+++ b/virtualization_11.m
@@ -100,7 +100,7 @@
         processName,
         osVersion,
         architecture,
-        networkDevice,
+        [networkDevice debugDescription],
         networkDevice.attachment,
         error);
 }

--- a/virtualization_11.m
+++ b/virtualization_11.m
@@ -103,6 +103,17 @@
         [networkDevice debugDescription],
         networkDevice.attachment,
         error);
+
+    int i = 0;
+    for (VZNetworkDevice *nd in virtualMachine.networkDevices) {
+        if (nd == networkDevice) {
+            NSLog(@"Index network devices %d, %@", i, nd.attachment);
+            break;
+        }
+        i++;
+    }
+    NSLog(@"debug is finished");
+    [networkDevice setAttachment:[[VZNATNetworkDeviceAttachment alloc] init]];
 }
 @end
 

--- a/virtualization_14.h
+++ b/virtualization_14.h
@@ -24,6 +24,6 @@ void *newVZNetworkBlockDeviceStorageDeviceAttachment(const char *url, double tim
 
 @interface VZNetworkBlockDeviceStorageDeviceAttachmentDelegateImpl : NSObject <VZNetworkBlockDeviceStorageDeviceAttachmentDelegate>
 - (instancetype)initWithHandle:(uintptr_t)cgoHandle;
-- (void)attachment:(VZNetworkBlockDeviceStorageDeviceAttachment *)attachment didEncounterError:(NSError *)error;
-- (void)attachmentWasConnected:(VZNetworkBlockDeviceStorageDeviceAttachment *)attachment;
+- (void)attachment:(VZNetworkBlockDeviceStorageDeviceAttachment *)attachment didEncounterError:(NSError *)error API_AVAILABLE(macos(14.0));
+- (void)attachmentWasConnected:(VZNetworkBlockDeviceStorageDeviceAttachment *)attachment API_AVAILABLE(macos(14.0));
 @end

--- a/virtualization_test.go
+++ b/virtualization_test.go
@@ -3,6 +3,7 @@ package vz_test
 import (
 	"errors"
 	"fmt"
+	"log"
 	"math"
 	"net"
 	"os"
@@ -172,6 +173,16 @@ func newVirtualizationMachine(
 		t.Fatal("want CanStart is true")
 	}
 
+	// As it is not possible to intentionally cause errors, only logging is possible.
+	disconnected, err := vm.NetworkDeviceAttachmentWasDisconnected()
+	if err == nil {
+		go func() {
+			for disconnected := range disconnected {
+				log.Println(disconnected)
+			}
+		}()
+	}
+
 	if err := vm.Start(); err != nil {
 		t.Fatal(err)
 	}
@@ -187,6 +198,10 @@ func newVirtualizationMachine(
 	// does not seem to have a connection timeout set.
 	if vz.Available(12) {
 		time.Sleep(5 * time.Second)
+	} else {
+		// Not immediately available in the x86_64 environment
+		// so wait a little longer for the orbit before testing.
+		time.Sleep(3 * time.Second)
 	}
 
 	const max = 5

--- a/virtualization_view.m
+++ b/virtualization_view.m
@@ -178,7 +178,7 @@
 {
     self = [super init];
     _virtualMachine = virtualMachine;
-    _virtualMachine.delegate = self;
+    [_virtualMachine setDelegate:self];
 
     // Setup virtual machine view configs
     VZVirtualMachineView *view = [[[VZVirtualMachineView alloc] init] autorelease];


### PR DESCRIPTION
## Which issue(s) this PR fixes:

Related #118

## Additional documentation

This Pull Request adds support for `attachmentWasDisconnectedWithError` only on the Objective-C side. The reason it’s not provided as a Go API is that I couldn’t reproduce the invocation of this method in my environment, so I couldn’t determine the appropriate way to expose it as a Go API.

Things I tried (building `example/macOS`):
  - Modified the internal code to release the `VZNetworkDevice` and its attachment after the VM started
    - The network remained functional
  - Deleted the file descriptor passed to `vz.NewFileHandleNetworkDeviceAttachment` after the VM started
    - Network functionality stopped, but `attachmentWasDisconnectedWithError` was not executed
    - I also tried this while macOS was running, with the same result

Based on these findings, I decided to log the error content as an `NSLog` in Objective-C for now and have users report it if it occurs.

You can see log like below:

```
2024-11-03 14:28:02.354 virtualization[30280:5308173] If you see this message, please report the information about the OS (including the version) that you are running on the VM, along with the information displayed below, to https://github.com/Code-Hex/vz/issues.
Process Information:
  Name: virtualization
  macOS: Version 14.5 (Build 23F79), arm64
  networkDevice: <VZNetworkDevice: 0x6000010d86c0>
  networkDevice attachment: <VZNATNetworkDeviceAttachment: 0x600001cd80b0>
  attachmentWasDisconnectedWithError: <error content>
```
