### PR TITLE
make flaky tests more stable

### DIFF
--- a/issues_test.go
+++ b/issues_test.go
@@ -49,15 +49,30 @@ func TestIssue50(t *testing.T) {
 	}
 
 	t.Run("check for segmentation faults", func(t *testing.T) {
-		cases := map[string]func() error{
-			"start handler":  func() error { return m.Start() },
-			"pause handler":  m.Pause,
-			"resume handler": m.Resume,
-			"stop handler":   m.Stop,
+		cases := []struct {
+			name string
+			run  func() error
+		}{
+			{
+				name: "start handler",
+				run:  func() error { return m.Start() },
+			},
+			{
+				name: "pause handler",
+				run:  m.Pause,
+			},
+			{
+				name: "resume handler",
+				run:  m.Resume,
+			},
+			{
+				name: "stop handler",
+				run:  m.Stop,
+			},
 		}
-		for name, run := range cases {
-			t.Run(name, func(t *testing.T) {
-				_ = run()
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				_ = tc.run()
 			})
 		}
 	})

--- a/socket_test.go
+++ b/socket_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"log"
 	"testing"
 	"time"
 
@@ -12,7 +13,11 @@ import (
 
 func TestVirtioSocketListener(t *testing.T) {
 	container := newVirtualizationMachine(t)
-	defer container.Close()
+	t.Cleanup(func() {
+		if err := container.Shutdown(); err != nil {
+			log.Println(err)
+		}
+	})
 
 	vm := container.VirtualMachine
 

--- a/storage_test.go
+++ b/storage_test.go
@@ -1,6 +1,7 @@
 package vz_test
 
 import (
+	"log"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -76,7 +77,7 @@ func TestBlockDeviceWithCacheAndSyncMode(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			attachment, err := vz.NewDiskImageStorageDeviceAttachmentWithCacheAndSync(path, false, vz.DiskImageCachingModeAutomatic, vz.DiskImageSynchronizationModeFsync)
+			attachment, err := vz.NewDiskImageStorageDeviceAttachmentWithCacheAndSync(path, false, vz.DiskImageCachingModeCached, vz.DiskImageSynchronizationModeFsync)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -90,7 +91,11 @@ func TestBlockDeviceWithCacheAndSyncMode(t *testing.T) {
 			return nil
 		},
 	)
-	defer container.Close()
+	t.Cleanup(func() {
+		if err := container.Shutdown(); err != nil {
+			log.Println(err)
+		}
+	})
 
 	vm := container.VirtualMachine
 


### PR DESCRIPTION
As shown in the screenshot, there are still flaky test issues.

This PR fixes the VMs started by each test to stop on exit. There seem to be fewer cases of macOS runner freezing during testing. There is still the occasional problem of starting up but not being able to connect vsock, which will be dealt with separately.

![CleanShot 2024-11-07 at 20 36 10@2x](https://github.com/user-attachments/assets/23a4adfc-e5eb-40af-90b5-7bd597a15987)

I tried on: https://github.com/Code-Hex/vz-ci-test/actions
