### PR TITLE
feat: add ASIF support (macOS 26.0)

### DIFF
--- a/disk.go
+++ b/disk.go
@@ -1,7 +1,11 @@
 package vz
 
 import (
+	"context"
+	"fmt"
 	"os"
+	"os/exec"
+	"strconv"
 )
 
 // CreateDiskImage is creating disk image with specified filename and filesize.
@@ -19,5 +23,39 @@ func CreateDiskImage(pathname string, size int64) error {
 	if err := f.Truncate(size); err != nil {
 		return err
 	}
+	return nil
+}
+
+// CreateSparseDiskImage is creating an "Apple Sparse Image Format" disk image
+// with specified filename and filesize. The function "shells out" to diskutil, as currently
+// this is the only known way of creating ASIF images.
+// For example, if you want to create disk with 64GiB, you can set "64 * 1024 * 1024 * 1024" to size.
+//
+// Note that ASIF is only available from macOS Tahoe, so the function will return error
+// on earlier versions.
+func CreateSparseDiskImage(ctx context.Context, pathname string, size int64) error {
+	if err := macOSAvailable(26); err != nil {
+		return err
+	}
+	diskutil, err := exec.LookPath("diskutil")
+	if err != nil {
+		return fmt.Errorf("failed to find disktuil: %w", err)
+	}
+
+	sizeStr := strconv.FormatInt(size, 10)
+	cmd := exec.CommandContext(ctx,
+		diskutil,
+		"image",
+		"create",
+		"blank",
+		"--fs", "none",
+		"--format", "ASIF",
+		"--size", sizeStr,
+		pathname)
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to create ASIF disk image: %w", err)
+	}
+
 	return nil
 }

--- a/disk_test.go
+++ b/disk_test.go
@@ -1,0 +1,113 @@
+package vz_test
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/Code-Hex/vz/v3"
+)
+
+func TestCreateSparseDiskImage_FileCreated(t *testing.T) {
+	if vz.Available(26) {
+		t.Skip("CreateSparseDiskImage is supported from macOS 26")
+	}
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sparse_disk.img")
+
+	ctx := context.Background()
+	size := int64(1024 * 1024 * 1024) // 1 GiB
+
+	err := vz.CreateSparseDiskImage(ctx, path, size)
+	if err != nil {
+		t.Fatalf("failed to create sparse disk image: %v", err)
+	}
+
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		t.Fatal("disk image file was not created")
+	}
+}
+
+func TestCreateSparseDiskImage_ASIFFormat(t *testing.T) {
+	if vz.Available(26) {
+		t.Skip("CreateSparseDiskImage is supported from macOS 26")
+	}
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sparse_disk.img")
+
+	ctx := context.Background()
+	size := int64(1024 * 1024 * 1024) // 1 GiB
+
+	err := vz.CreateSparseDiskImage(ctx, path, size)
+	if err != nil {
+		t.Fatalf("failed to create sparse disk image: %v", err)
+	}
+
+	// Check if the format is ASIF using diskutil
+	cmd := exec.Command("diskutil", "image", "info", path)
+	output, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("failed to get disk image info: %v", err)
+	}
+
+	outputStr := string(output)
+	lines := strings.Split(outputStr, "\n")
+
+	foundASIF := false
+	// Check if ASIF is mentioned in the first line
+	if len(lines) != 0 && strings.Contains(lines[0], "ASIF") {
+		foundASIF = true
+	}
+
+	if !foundASIF {
+		t.Errorf("disk image is not in ASIF format. Output: %v", lines[:1])
+	}
+}
+
+func TestCreateSparseDiskImage_CorrectSize(t *testing.T) {
+	if vz.Available(26) {
+		t.Skip("CreateSparseDiskImage is supported from macOS 26")
+	}
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sparse_disk.img")
+
+	ctx := context.Background()
+	desiredSize := int64(2 * 1024 * 1024 * 1024) // 2 GiB
+
+	err := vz.CreateSparseDiskImage(ctx, path, desiredSize)
+	if err != nil {
+		t.Fatalf("failed to create sparse disk image: %v", err)
+	}
+
+	cmd := exec.Command("diskutil", "image", "info", path)
+	output, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("failed to get disk image info: %v", err)
+	}
+
+	var sizeStr string
+	for _, line := range strings.Split(string(output), "\n") {
+		if strings.Contains(line, "Total Bytes") {
+			components := strings.Split(strings.TrimSpace(line), ":")
+			if len(components) > 1 {
+				sizeStr = strings.TrimSpace(components[1])
+				break
+			}
+		}
+	}
+	actualSize, err := strconv.ParseInt(sizeStr, 10, 64)
+	if err != nil {
+		t.Fatalf("failed to parse string to int: %v", err)
+	}
+
+	if desiredSize != actualSize {
+		t.Fatalf("actual disk size (%d) doesn't equal to desired size (%d)", actualSize, desiredSize)
+	}
+}

--- a/example/macOS/installer.go
+++ b/example/macOS/installer.go
@@ -29,6 +29,7 @@ func installMacOS(ctx context.Context) error {
 	}
 	configurationRequirements := restoreImage.MostFeaturefulSupportedConfiguration()
 	config, err := setupVirtualMachineWithMacOSConfigurationRequirements(
+		ctx,
 		configurationRequirements,
 	)
 	if err != nil {
@@ -67,12 +68,12 @@ func installMacOS(ctx context.Context) error {
 	return installer.Install(ctx)
 }
 
-func setupVirtualMachineWithMacOSConfigurationRequirements(macOSConfiguration *vz.MacOSConfigurationRequirements) (*vz.VirtualMachineConfiguration, error) {
+func setupVirtualMachineWithMacOSConfigurationRequirements(ctx context.Context, macOSConfiguration *vz.MacOSConfigurationRequirements) (*vz.VirtualMachineConfiguration, error) {
 	platformConfig, err := createMacInstallerPlatformConfiguration(macOSConfiguration)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create mac platform config: %w", err)
 	}
-	return setupVMConfiguration(platformConfig)
+	return setupVMConfiguration(ctx, platformConfig)
 }
 
 func createMacInstallerPlatformConfiguration(macOSConfiguration *vz.MacOSConfigurationRequirements) (*vz.MacPlatformConfiguration, error) {


### PR DESCRIPTION
## Which issue(s) this PR fixes:
Not an issue but discussion:
https://github.com/Code-Hex/vz/discussions/189

## Additional documentation

The PR adds support for the new [Apple Sparse Image Format](https://developer.apple.com/documentation/virtualization/vzdiskimagestoragedeviceattachment) introduced by Tahoe (still beta).  Currently the only known way of creating ASIF images is via `diskutil`.

Tested on:
```bash
$ sw_vers
ProductName:            macOS
ProductVersion:         26.0
BuildVersion:           25A5346a
```

Testing evidence:

```bash
// installing in the "old" way, resulting in a plain raw image file
$ ./virtualization -install
install has been completed

$ diskutil image info ~/VM.bundle/Disk.img
Image Format: RAW
Format Description: RAW read-write image
// rest of the output is omitted

// installing with `-asif` flag, resulting in an ASIF disk image
$ ./virtualization -install -asif
install has been completed

$ diskutil image info ~/VM.bundle/Disk.img
Image Format: ASIF
Format Description: Apple sparse image
// rest of the output is omitted

```
The VM runs with ASIF disk as well:
<img width="1220" height="450" alt="Screenshot 2025-08-28 at 12 44 48" src="https://github.com/user-attachments/assets/78f11382-da5c-44a2-adee-586366c27617" />

I don't think we need to update any header files, as the `VZDiskImageStorageDeviceAttachment` and `VZVirtioBlockDeviceConfiguration` interfaces did not change. 

Let me know if you need anything else to accept the PR 🙇🏻 