### PR TITLE
Fix serial console attachment silently disabled by wrong error check

### DIFF
--- a/serial_console_test.go
+++ b/serial_console_test.go
@@ -1,0 +1,27 @@
+package vz_test
+
+import (
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/Code-Hex/vz/v3"
+	"github.com/Code-Hex/vz/v3/internal/objc"
+)
+
+// TestNewFileHandleSerialPortAttachment guards against a regression where the
+// constructor checked the error out-parameter pointer (always non-nil) instead
+// of the duplicated file handle, causing it to return a non-nil wrapper around a
+// NULL Objective-C object with a nil error. The serial console was silently lost.
+func TestNewFileHandleSerialPortAttachment(t *testing.T) {
+	attachment, err := vz.NewFileHandleSerialPortAttachment(os.Stdin, os.Stderr)
+	if errors.Is(err, vz.ErrUnsupportedOSVersion) {
+		t.Skipf("not supported on this macOS version: %v", err)
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	if objc.Ptr(attachment) == nil {
+		t.Fatal("attachment wraps a NULL pointer: constructor reported success but built nothing")
+	}
+}

--- a/virtualization_11.m
+++ b/virtualization_11.m
@@ -453,13 +453,16 @@ void *newVZFileHandleSerialPortAttachment(int readFileDescriptor, int writeFileD
     if (@available(macOS 11, *)) {
         VZFileHandleSerialPortAttachment *ret;
         @autoreleasepool {
+            // Check the returned handle, not `error`: `error` is the void** out-param (always
+            // non-nil), so `if (error != nil)` is always true. newFileHandleDupFd returns nil
+            // and sets *error only on failure. Matches newVZFileHandleNetworkDeviceAttachment.
             NSFileHandle *fileHandleForReading = newFileHandleDupFd(readFileDescriptor, error);
-            if (error != nil) {
+            if (fileHandleForReading == nil) {
                 return nil;
             }
 
             NSFileHandle *fileHandleForWriting = newFileHandleDupFd(writeFileDescriptor, error);
-            if (error != nil) {
+            if (fileHandleForWriting == nil) {
                 return nil;
             }
             ret = [[VZFileHandleSerialPortAttachment alloc]

--- a/virtualization_11.m
+++ b/virtualization_11.m
@@ -453,9 +453,6 @@ void *newVZFileHandleSerialPortAttachment(int readFileDescriptor, int writeFileD
     if (@available(macOS 11, *)) {
         VZFileHandleSerialPortAttachment *ret;
         @autoreleasepool {
-            // Check the returned handle, not `error`: `error` is the void** out-param (always
-            // non-nil), so `if (error != nil)` is always true. newFileHandleDupFd returns nil
-            // and sets *error only on failure. Matches newVZFileHandleNetworkDeviceAttachment.
             NSFileHandle *fileHandleForReading = newFileHandleDupFd(readFileDescriptor, error);
             if (fileHandleForReading == nil) {
                 return nil;


### PR DESCRIPTION
## Summary

`newVZFileHandleSerialPortAttachment` checked the **error out-parameter pointer** instead of the **returned file handle**, which silently disabled the file-handle serial console.

```objc
NSFileHandle *fileHandleForReading = newFileHandleDupFd(readFileDescriptor, error);
if (error != nil) {   // <-- always true: `error` is void** out-param (&caller's var)
    return nil;
}
```

Because callers always pass the address of their error variable (`&nserrPtr` in `serial_console.go`), `error != nil` is **always true**, so the function returned `nil` before ever building the attachment. On the Go side this produced a non-nil `*FileHandleSerialPortAttachment` wrapping a NULL Objective-C object with a **nil error** — a silent failure. The guest's serial console (`console=hvc0`) had nowhere to write.

## Fix

Check the duplicated handle returned by `newFileHandleDupFd`, which returns `nil` and sets `*error` only on `dup()` failure. This is the same pattern already used by `newVZFileHandleNetworkDeviceAttachment` (virtualization_11.m) and `newVZDiskBlockDeviceStorageDeviceAttachment` (virtualization_14.m).

```objc
NSFileHandle *fileHandleForReading = newFileHandleDupFd(readFileDescriptor, error);
if (fileHandleForReading == nil) {
    return nil;
}
```

This also aligns with Apple's Cocoa convention: success/failure is signaled by the return value, and the `NSError` out-parameter is only consulted on failure.

## Why existing tests didn't catch it

The bootable-VM integration test (`TestRun`) talks to the guest over **vsock/SSH**, not the serial console. A serial port with a nil attachment is valid config, so `Validate()` and `Start()` succeed; only the kernel boot log was lost, and nothing asserted on it. Added a focused unit test that asserts the constructor returns a non-NULL attachment.

## Test evidence

Run via `make test` (codesigns each test binary with the `com.apple.security.virtualization` entitlement; bare `go test` aborts with an uncaught `NSInvalidArgumentException` when creating a VM).

New regression test:
```
=== RUN   TestNewFileHandleSerialPortAttachment
--- PASS: TestNewFileHandleSerialPortAttachment (0.00s)
```

Verified the test actually catches the bug — temporarily reverting the checks to `if (error != nil)` makes it fail:
```
serial_console_test.go:25: attachment wraps a NULL pointer: constructor reported success but built nothing
--- FAIL: TestNewFileHandleSerialPortAttachment (0.00s)
```

Real VM boot now shows serial console output (`console=hvc0`) and completes the full SSH-over-vsock flow:
```
=== RUN   TestRun
[    0.080305] Run /init as init process
chpasswd: password for 'root' changed
udhcpc: lease of 192.168.64.19 obtained from 192.168.64.1, lease time 3600
Run socat as vsock ssh proxyserver (port=62026)
localhost login: ... container setup done
[    5.067368] reboot: Power down
--- PASS: TestRun (5.21s)
```

Full suite:
```
ok  github.com/Code-Hex/vz/v3                    55.311s
ok  github.com/Code-Hex/vz/v3/internal/progress   0.554s
ok  github.com/Code-Hex/vz/v3/internal/sliceutil  0.348s
```
(`TestRunIssue124` SKIP — gated behind `TEST_ISSUE_124=1`.)

## Local environment

| | |
|---|---|
| macOS | 26.5 (build 25F71) |
| Hardware | Apple M4 (arm64) |
| Go | go1.26.3 darwin/arm64 |
| Toolchain | Apple clang 21.0.0 (clang-2100.1.1.101) |
| Test kernel | puipui-linux v1.0.3 (aarch64) |

## Test plan

- [x] `make test` passes (full suite, incl. VM boot tests)
- [x] New regression test passes with the fix
- [x] New regression test fails when the bug is reintroduced
- [x] `go vet ./...` clean