### PR TITLE
build: deduplicate Objective-C runtime linkage

### DIFF
--- a/audio.go
+++ b/audio.go
@@ -2,7 +2,7 @@ package vz
 
 /*
 #cgo darwin CFLAGS: -mmacosx-version-min=11 -x objective-c -fno-objc-arc
-#cgo darwin LDFLAGS: -lobjc -framework Foundation -framework Virtualization
+#cgo darwin LDFLAGS: -framework Foundation -framework Virtualization
 # include "virtualization_11.h"
 # include "virtualization_12.h"
 */

--- a/bootloader.go
+++ b/bootloader.go
@@ -2,7 +2,7 @@ package vz
 
 /*
 #cgo darwin CFLAGS: -mmacosx-version-min=11 -x objective-c -fno-objc-arc
-#cgo darwin LDFLAGS: -lobjc -framework Foundation -framework Virtualization
+#cgo darwin LDFLAGS: -framework Foundation -framework Virtualization
 # include "virtualization_11.h"
 # include "virtualization_13.h"
 */

--- a/bootloader_arm64.go
+++ b/bootloader_arm64.go
@@ -5,7 +5,7 @@ package vz
 
 /*
 #cgo darwin CFLAGS: -mmacosx-version-min=11 -x objective-c -fno-objc-arc
-#cgo darwin LDFLAGS: -lobjc -framework Foundation -framework Virtualization
+#cgo darwin LDFLAGS: -framework Foundation -framework Virtualization
 # include "virtualization_12_arm64.h"
 */
 import "C"

--- a/cgoutil.go
+++ b/cgoutil.go
@@ -2,7 +2,7 @@ package vz
 
 /*
 #cgo darwin CFLAGS: -mmacosx-version-min=11 -x objective-c
-#cgo darwin LDFLAGS: -lobjc -framework Foundation
+#cgo darwin LDFLAGS: -framework Foundation
 #import <Foundation/Foundation.h>
 
 

--- a/clipboard.go
+++ b/clipboard.go
@@ -2,7 +2,7 @@ package vz
 
 /*
 #cgo darwin CFLAGS: -mmacosx-version-min=11 -x objective-c -fno-objc-arc
-#cgo darwin LDFLAGS: -lobjc -framework Foundation -framework Virtualization
+#cgo darwin LDFLAGS: -framework Foundation -framework Virtualization
 # include "virtualization_13.h"
 */
 import "C"

--- a/configuration.go
+++ b/configuration.go
@@ -2,7 +2,7 @@ package vz
 
 /*
 #cgo darwin CFLAGS: -mmacosx-version-min=11 -x objective-c -fno-objc-arc
-#cgo darwin LDFLAGS: -lobjc -framework Foundation -framework Virtualization
+#cgo darwin LDFLAGS: -framework Foundation -framework Virtualization
 # include "virtualization_11.h"
 # include "virtualization_12.h"
 # include "virtualization_13.h"

--- a/configuration_arm64.go
+++ b/configuration_arm64.go
@@ -5,7 +5,7 @@ package vz
 
 /*
 #cgo darwin CFLAGS: -mmacosx-version-min=11 -x objective-c -fno-objc-arc
-#cgo darwin LDFLAGS: -lobjc -framework Foundation -framework Virtualization
+#cgo darwin LDFLAGS: -framework Foundation -framework Virtualization
 # include "virtualization_14_arm64.h"
 */
 import "C"

--- a/console.go
+++ b/console.go
@@ -2,7 +2,7 @@ package vz
 
 /*
 #cgo darwin CFLAGS: -mmacosx-version-min=11 -x objective-c -fno-objc-arc
-#cgo darwin LDFLAGS: -lobjc -framework Foundation -framework Virtualization
+#cgo darwin LDFLAGS: -framework Foundation -framework Virtualization
 # include "virtualization_13.h"
 */
 import "C"

--- a/debug.go
+++ b/debug.go
@@ -5,7 +5,7 @@ package vz
 
 /*
 #cgo darwin CFLAGS: -mmacosx-version-min=11 -x objective-c -fno-objc-arc
-#cgo darwin LDFLAGS: -lobjc -framework Foundation -framework Virtualization
+#cgo darwin LDFLAGS: -framework Foundation -framework Virtualization
 # include "virtualization_debug.h"
 */
 import "C"

--- a/entropy.go
+++ b/entropy.go
@@ -2,7 +2,7 @@ package vz
 
 /*
 #cgo darwin CFLAGS: -mmacosx-version-min=11 -x objective-c -fno-objc-arc
-#cgo darwin LDFLAGS: -lobjc -framework Foundation -framework Virtualization
+#cgo darwin LDFLAGS: -framework Foundation -framework Virtualization
 # include "virtualization_11.h"
 */
 import "C"

--- a/graphics.go
+++ b/graphics.go
@@ -2,7 +2,7 @@ package vz
 
 /*
 #cgo darwin CFLAGS: -mmacosx-version-min=11 -x objective-c -fno-objc-arc
-#cgo darwin LDFLAGS: -lobjc -framework Foundation -framework Virtualization
+#cgo darwin LDFLAGS: -framework Foundation -framework Virtualization
 # include "virtualization_13.h"
 */
 import "C"

--- a/graphics_arm64.go
+++ b/graphics_arm64.go
@@ -5,7 +5,7 @@ package vz
 
 /*
 #cgo darwin CFLAGS: -mmacosx-version-min=11 -x objective-c -fno-objc-arc
-#cgo darwin LDFLAGS: -lobjc -framework Foundation -framework Virtualization
+#cgo darwin LDFLAGS: -framework Foundation -framework Virtualization
 # include "virtualization_12_arm64.h"
 */
 import "C"

--- a/internal/objc/objc.go
+++ b/internal/objc/objc.go
@@ -2,7 +2,7 @@ package objc
 
 /*
 #cgo darwin CFLAGS: -mmacosx-version-min=11 -x objective-c
-#cgo darwin LDFLAGS: -lobjc -framework Foundation
+#cgo darwin LDFLAGS: -framework Foundation
 #import <Foundation/Foundation.h>
 
 void *makeNSMutableArray(unsigned long cap)

--- a/keyboard.go
+++ b/keyboard.go
@@ -2,7 +2,7 @@ package vz
 
 /*
 #cgo darwin CFLAGS: -mmacosx-version-min=11 -x objective-c -fno-objc-arc
-#cgo darwin LDFLAGS: -lobjc -framework Foundation -framework Virtualization
+#cgo darwin LDFLAGS: -framework Foundation -framework Virtualization
 # include "virtualization_11.h"
 # include "virtualization_12.h"
 */

--- a/keyboard_arm64.go
+++ b/keyboard_arm64.go
@@ -5,7 +5,7 @@ package vz
 
 /*
 #cgo darwin CFLAGS: -mmacosx-version-min=11 -x objective-c -fno-objc-arc
-#cgo darwin LDFLAGS: -lobjc -framework Foundation -framework Virtualization
+#cgo darwin LDFLAGS: -framework Foundation -framework Virtualization
 # include "virtualization_14_arm64.h"
 */
 import "C"

--- a/memory_balloon.go
+++ b/memory_balloon.go
@@ -2,7 +2,7 @@ package vz
 
 /*
 #cgo darwin CFLAGS: -mmacosx-version-min=11 -x objective-c -fno-objc-arc
-#cgo darwin LDFLAGS: -lobjc -framework Foundation -framework Virtualization
+#cgo darwin LDFLAGS: -framework Foundation -framework Virtualization
 # include "virtualization_11.h"
 */
 import "C"

--- a/network.go
+++ b/network.go
@@ -2,7 +2,7 @@ package vz
 
 /*
 #cgo darwin CFLAGS: -mmacosx-version-min=11 -x objective-c -fno-objc-arc
-#cgo darwin LDFLAGS: -lobjc -framework Foundation -framework Virtualization
+#cgo darwin LDFLAGS: -framework Foundation -framework Virtualization
 # include "virtualization_11.h"
 # include "virtualization_13.h"
 */

--- a/osversion.go
+++ b/osversion.go
@@ -2,7 +2,7 @@ package vz
 
 /*
 #cgo darwin CFLAGS: -mmacosx-version-min=11 -x objective-c -fno-objc-arc
-#cgo darwin LDFLAGS: -lobjc -framework Foundation
+#cgo darwin LDFLAGS: -framework Foundation
 # include "virtualization_helper.h"
 */
 import "C"

--- a/platform.go
+++ b/platform.go
@@ -2,7 +2,7 @@ package vz
 
 /*
 #cgo darwin CFLAGS: -mmacosx-version-min=11 -x objective-c -fno-objc-arc
-#cgo darwin LDFLAGS: -lobjc -framework Foundation -framework Virtualization
+#cgo darwin LDFLAGS: -framework Foundation -framework Virtualization
 # include "virtualization_11.h"
 # include "virtualization_12.h"
 # include "virtualization_13.h"

--- a/platform_arm64.go
+++ b/platform_arm64.go
@@ -5,7 +5,7 @@ package vz
 
 /*
 #cgo darwin CFLAGS: -mmacosx-version-min=11 -x objective-c -fno-objc-arc
-#cgo darwin LDFLAGS: -lobjc -framework Foundation -framework Virtualization
+#cgo darwin LDFLAGS: -framework Foundation -framework Virtualization
 # include "virtualization_12_arm64.h"
 */
 import "C"

--- a/pointing_device.go
+++ b/pointing_device.go
@@ -2,7 +2,7 @@ package vz
 
 /*
 #cgo darwin CFLAGS: -mmacosx-version-min=11 -x objective-c -fno-objc-arc
-#cgo darwin LDFLAGS: -lobjc -framework Foundation -framework Virtualization
+#cgo darwin LDFLAGS: -framework Foundation -framework Virtualization
 # include "virtualization_11.h"
 # include "virtualization_12.h"
 */

--- a/pointing_device_arm64.go
+++ b/pointing_device_arm64.go
@@ -5,7 +5,7 @@ package vz
 
 /*
 #cgo darwin CFLAGS: -mmacosx-version-min=11 -x objective-c -fno-objc-arc
-#cgo darwin LDFLAGS: -lobjc -framework Foundation -framework Virtualization
+#cgo darwin LDFLAGS: -framework Foundation -framework Virtualization
 # include "virtualization_13_arm64.h"
 */
 import "C"

--- a/serial_console.go
+++ b/serial_console.go
@@ -2,7 +2,7 @@ package vz
 
 /*
 #cgo darwin CFLAGS: -mmacosx-version-min=11 -x objective-c -fno-objc-arc
-#cgo darwin LDFLAGS: -lobjc -framework Foundation -framework Virtualization
+#cgo darwin LDFLAGS: -framework Foundation -framework Virtualization
 # include "virtualization_11.h"
 */
 import "C"

--- a/shared_directory.go
+++ b/shared_directory.go
@@ -2,7 +2,7 @@ package vz
 
 /*
 #cgo darwin CFLAGS: -mmacosx-version-min=11 -x objective-c -fno-objc-arc
-#cgo darwin LDFLAGS: -lobjc -framework Foundation -framework Virtualization
+#cgo darwin LDFLAGS: -framework Foundation -framework Virtualization
 # include "virtualization_11.h"
 # include "virtualization_12.h"
 # include "virtualization_13.h"

--- a/shared_directory_arm64.go
+++ b/shared_directory_arm64.go
@@ -5,7 +5,7 @@ package vz
 
 /*
 #cgo darwin CFLAGS: -mmacosx-version-min=11 -x objective-c -fno-objc-arc
-#cgo darwin LDFLAGS: -lobjc -framework Foundation -framework Virtualization
+#cgo darwin LDFLAGS: -framework Foundation -framework Virtualization
 # include "virtualization_13_arm64.h"
 # include "virtualization_14_arm64.h"
 */

--- a/socket.go
+++ b/socket.go
@@ -2,7 +2,7 @@ package vz
 
 /*
 #cgo darwin CFLAGS: -mmacosx-version-min=11 -x objective-c -fno-objc-arc
-#cgo darwin LDFLAGS: -lobjc -framework Foundation -framework Virtualization
+#cgo darwin LDFLAGS: -framework Foundation -framework Virtualization
 # include "virtualization_11.h"
 */
 import "C"

--- a/storage.go
+++ b/storage.go
@@ -2,7 +2,7 @@ package vz
 
 /*
 #cgo darwin CFLAGS: -mmacosx-version-min=11 -x objective-c -fno-objc-arc
-#cgo darwin LDFLAGS: -lobjc -framework Foundation -framework Virtualization
+#cgo darwin LDFLAGS: -framework Foundation -framework Virtualization
 # include "virtualization_11.h"
 # include "virtualization_12.h"
 # include "virtualization_12_3.h"

--- a/usb.go
+++ b/usb.go
@@ -2,7 +2,7 @@ package vz
 
 /*
 #cgo darwin CFLAGS: -mmacosx-version-min=11 -x objective-c -fno-objc-arc
-#cgo darwin LDFLAGS: -lobjc -framework Foundation -framework Virtualization
+#cgo darwin LDFLAGS: -framework Foundation -framework Virtualization
 # include "virtualization_15.h"
 */
 import "C"

--- a/virtualization.go
+++ b/virtualization.go
@@ -2,7 +2,7 @@ package vz
 
 /*
 #cgo darwin CFLAGS: -mmacosx-version-min=11 -x objective-c -fno-objc-arc
-#cgo darwin LDFLAGS: -lobjc -framework Foundation -framework Virtualization -framework Cocoa
+#cgo darwin LDFLAGS: -framework Foundation -framework Virtualization -framework Cocoa
 # include "virtualization_11.h"
 # include "virtualization_12.h"
 # include "virtualization_13.h"

--- a/virtualization_arm64.go
+++ b/virtualization_arm64.go
@@ -5,7 +5,7 @@ package vz
 
 /*
 #cgo darwin CFLAGS: -mmacosx-version-min=11 -x objective-c -fno-objc-arc
-#cgo darwin LDFLAGS: -lobjc -framework Foundation -framework Virtualization
+#cgo darwin LDFLAGS: -framework Foundation -framework Virtualization
 # include "virtualization_11.h"
 # include "virtualization_12_arm64.h"
 # include "virtualization_13_arm64.h"


### PR DESCRIPTION
## Summary

- Remove redundant explicit `-lobjc` flags from Darwin cgo directives.
- Keep all existing Foundation, Virtualization, and Cocoa framework links unchanged.
- Rely on cgo/clang's Objective-C runtime linkage, which already contributes the required single runtime link.

This removes the Apple linker warning:

```text
ld: warning: ignoring duplicate libraries: '-lobjc'
```

The warning was visible downstream because each Objective-C source file contributed another explicit `-lobjc` to the package link command.

## Verification

- `go test -run '^$' . ./internal/objc` (clean compile; warning absent)
- `go test -run '^$' ./...`
- `go vet ./...`
- `git diff --check`
