### PR TITLE
audio: expose output stream without a host sink

### DIFF
--- a/audio.go
+++ b/audio.go
@@ -109,6 +109,37 @@ func NewVirtioSoundDeviceHostInputStreamConfiguration() (*VirtioSoundDeviceHostI
 	return config, nil
 }
 
+// VirtioSoundDeviceOutputStreamConfiguration defines a PCM output stream whose
+// audio is suppressed by the host. Virtualization keeps the stream clocked while
+// discarding the samples when no sink is configured.
+type VirtioSoundDeviceOutputStreamConfiguration struct {
+	*pointer
+
+	*baseVirtioSoundDeviceStreamConfiguration
+}
+
+var _ VirtioSoundDeviceStreamConfiguration = (*VirtioSoundDeviceOutputStreamConfiguration)(nil)
+
+// NewVirtioSoundDeviceOutputStreamConfiguration creates a new sound device
+// output stream configuration without a host audio sink.
+//
+// This is only supported on macOS 12 and newer, error will be returned
+// on older versions.
+func NewVirtioSoundDeviceOutputStreamConfiguration() (*VirtioSoundDeviceOutputStreamConfiguration, error) {
+	if err := macOSAvailable(12); err != nil {
+		return nil, err
+	}
+	config := &VirtioSoundDeviceOutputStreamConfiguration{
+		pointer: objc.NewPointer(
+			C.newVZVirtioSoundDeviceOutputStreamConfiguration(),
+		),
+	}
+	objc.SetFinalizer(config, func(self *VirtioSoundDeviceOutputStreamConfiguration) {
+		objc.Release(self)
+	})
+	return config, nil
+}
+
 // VirtioSoundDeviceHostOutputStreamConfiguration is a struct that
 // defines a Virtio host sound device output stream configuration.
 //

--- a/osversion_test.go
+++ b/osversion_test.go
@@ -119,6 +119,10 @@ func TestAvailableVersion(t *testing.T) {
 				_, err := NewVirtioSoundDeviceHostInputStreamConfiguration()
 				return err
 			},
+			"NewVirtioSoundDeviceOutputStreamConfiguration": func() error {
+				_, err := NewVirtioSoundDeviceOutputStreamConfiguration()
+				return err
+			},
 			"NewVirtioSoundDeviceHostOutputStreamConfiguration": func() error {
 				_, err := NewVirtioSoundDeviceHostOutputStreamConfiguration()
 				return err


### PR DESCRIPTION
## Which issue(s) this PR fixes:

Fixes #222

## Additional documentation

This exposes the base `VZVirtioSoundDeviceOutputStreamConfiguration` through the Go API without assigning a `VZHostAudioOutputStreamSink`.

The Objective-C constructor already exists in `virtualization_12.m`; this change adds the matching Go wrapper, constructor, finalizer, interface assertion, and macOS 12 availability coverage. Existing host-audio input and output constructors are unchanged.

Apple documents that the output stream's sink defaults to `nil` and that omitting a sink suppresses the audio:

https://developer.apple.com/documentation/virtualization/vzvirtiosounddeviceoutputstreamconfiguration/sink

This is useful for headless VMs that need to expose a playback device to the guest without depending on or playing through the host's default audio device.

### Validation

- `go test . -run '^TestAvailableVersion$' -count=1`
- Downstream end-to-end testing on macOS 15 and macOS 26 guests confirmed that the configured device becomes the default CoreAudio output and supplies render callbacks.

This pull request was prepared with AI assistance and reviewed and validated against the native API and downstream end-to-end behavior.